### PR TITLE
Initial release: signed, transparent Pi launcher for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build unsigned app and run full test suite
+    runs-on: macos-26
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint shell scripts
+        run: |
+          set -euo pipefail
+          for f in scripts/*.sh; do
+            bash -n "$f"
+          done
+          brew list --versions shellcheck >/dev/null 2>&1 || brew install shellcheck --quiet
+          shellcheck -S warning scripts/*.sh
+
+      - name: Compile with strict warnings
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          clang -O2 -std=c11 -Wall -Wextra -Wpedantic -Werror \
+            -arch arm64 -mmacosx-version-min=13.0 \
+            -o build/pi-launcher src/pi-launcher.c
+
+      - name: Fetch and verify the pinned upstream Pi release
+        run: scripts/fetch-pi.sh
+
+      - name: Build the unsigned development app
+        run: scripts/build-app.sh
+
+      - name: Run functional tests
+        run: make test-functional
+
+      - name: Run pseudo-terminal tests
+        run: make test-pty
+
+      - name: Run bundled-Pi smoke test
+        run: make test-smoke
+
+  contract:
+    name: Validate release pipeline and packaging contracts
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check release contracts
+        run: python3 scripts/check-release-contract.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,284 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag to build, for example v1.0.0
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.tag_name || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  TEAM_ID: 9T2J7MNUP9
+  BUNDLE_ID: com.kunchenguid.pi-launcher
+  SIGN_IDENTITY: "Developer ID Application: Kun Chen (9T2J7MNUP9)"
+  APP_NAME: "Pi Launcher.app"
+
+jobs:
+  release:
+    name: Build, sign, notarize, and publish
+    runs-on: macos-26
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
+
+      - name: Resolve release version
+        id: version
+        env:
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_NAME="${INPUT_TAG_NAME:-$REF_NAME}"
+          RELEASE_VERSION="${TAG_NAME#v}"
+          if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag '$TAG_NAME' must resolve to a version like 1.2.3" >&2
+            exit 1
+          fi
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          ZIP_NAME="Pi-Launcher-${RELEASE_VERSION}.zip"
+          echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+          echo "Releasing pi-launcher $RELEASE_VERSION from $TAG_NAME"
+
+      - name: Restore App Store Connect API key
+        id: asc-key
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          : "${APP_STORE_CONNECT_KEY_ID:?Missing APP_STORE_CONNECT_KEY_ID: set it with: printf '%s' 'KEY_ID' | gh secret set APP_STORE_CONNECT_KEY_ID --repo kunchenguid/pi-launcher}"
+          : "${APP_STORE_CONNECT_ISSUER_ID:?Missing APP_STORE_CONNECT_ISSUER_ID: set it with: printf '%s' 'ISSUER_ID' | gh secret set APP_STORE_CONNECT_ISSUER_ID --repo kunchenguid/pi-launcher}"
+          : "${APP_STORE_CONNECT_API_KEY:?Missing APP_STORE_CONNECT_API_KEY: set it with: base64 -i AuthKey_KEYID.p8 | gh secret set APP_STORE_CONNECT_API_KEY --repo kunchenguid/pi-launcher}"
+
+          mkdir -p "$HOME/private_keys"
+          KEY_PATH="$HOME/private_keys/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          export KEY_PATH
+
+          python3 <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          key_path = Path(os.environ["KEY_PATH"])
+          encoded = os.environ["APP_STORE_CONNECT_API_KEY"]
+          key_path.write_bytes(base64.b64decode(encoded))
+          PY
+
+          chmod 600 "$KEY_PATH"
+          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Developer ID Application certificate
+        id: developer_id_cert
+        env:
+          MAC_DEVELOPER_ID_CERT_P12: ${{ secrets.MAC_DEVELOPER_ID_CERT_P12 }}
+          MAC_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MAC_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${MAC_DEVELOPER_ID_CERT_P12:-}" ]; then
+            echo "::error title=Missing MAC_DEVELOPER_ID_CERT_P12::The Developer ID Application p12 secret is empty. Re-set it with: base64 -i DeveloperID_Application.p12 | tr -d '\n' | gh secret set MAC_DEVELOPER_ID_CERT_P12 --repo kunchenguid/pi-launcher" >&2
+            exit 1
+          fi
+          if [ -z "${MAC_DEVELOPER_ID_CERT_PASSWORD:-}" ]; then
+            echo "::error title=Missing MAC_DEVELOPER_ID_CERT_PASSWORD::Set the p12 export password with: printf '%s' 'THE_P12_PASSWORD' | gh secret set MAC_DEVELOPER_ID_CERT_PASSWORD --repo kunchenguid/pi-launcher" >&2
+            exit 1
+          fi
+
+          CERT_PATH="$RUNNER_TEMP/DeveloperID_Application.p12"
+          export CERT_PATH
+
+          python3 <<'PY'
+          import base64
+          import binascii
+          import os
+          import sys
+          from pathlib import Path
+
+          encoded = os.environ["MAC_DEVELOPER_ID_CERT_P12"]
+          normalized = "".join(encoded.split())
+          if not normalized:
+              print("::error title=Missing MAC_DEVELOPER_ID_CERT_P12::The secret is empty after whitespace normalization.", file=sys.stderr)
+              sys.exit(1)
+          try:
+              decoded = base64.b64decode(normalized, validate=True)
+          except binascii.Error as exc:
+              print(f"::error title=Invalid MAC_DEVELOPER_ID_CERT_P12::Not valid base64: {exc}", file=sys.stderr)
+              sys.exit(1)
+          if not decoded:
+              print("::error title=Invalid MAC_DEVELOPER_ID_CERT_P12::The secret decoded to an empty file.", file=sys.stderr)
+              sys.exit(1)
+          Path(os.environ["CERT_PATH"]).write_bytes(decoded)
+          PY
+
+          chmod 600 "$CERT_PATH"
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/pi-launcher-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)-$(uuidgen)"
+          export KEYCHAIN_PATH KEYCHAIN_PASSWORD
+
+          # The keychain must survive this step: codesign runs in a later
+          # step. The final cleanup step deletes it (runners are ephemeral,
+          # but tidy is tidy).
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          IMPORT_LOG="$RUNNER_TEMP/developer-id-import.log"
+          if ! security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -f pkcs12 -P "$MAC_DEVELOPER_ID_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security >"$IMPORT_LOG" 2>&1; then
+            IMPORT_ERROR="$(tr '\n' ' ' < "$IMPORT_LOG" | sed 's/[[:space:]]\+/ /g' | cut -c 1-800)"
+            echo "::error title=Invalid Developer ID certificate::The decoded MAC_DEVELOPER_ID_CERT_P12 could not be imported. Usually this means MAC_DEVELOPER_ID_CERT_PASSWORD is wrong or the p12 export is malformed. security import: $IMPORT_ERROR" >&2
+            exit 1
+          fi
+
+          # codesign must find the keychain and must not trigger an interactive
+          # partition-list prompt on the headless runner.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed -e 's/ *"//g' -e 's/"//g' | tr '\n' ' ')
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+
+          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "$SIGN_IDENTITY"; then
+            echo "::error title=Wrong signing identity::The restored keychain does not contain '$SIGN_IDENTITY'. The Developer ID Application certificate must belong to Team $TEAM_ID." >&2
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" >&2 || true
+            exit 1
+          fi
+
+          echo "keychain_path=$KEYCHAIN_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch and verify the pinned upstream Pi release
+        run: |
+          set -euo pipefail
+          scripts/fetch-pi.sh
+          echo "pi_version=$(python3 -c "import json; print(json.load(open('packaging/pi-release.json'))['version'])")" >> "$GITHUB_ENV"
+
+      - name: Build the app bundle
+        env:
+          VERSION: ${{ steps.version.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          scripts/build-app.sh
+          echo "app_path=build/$APP_NAME" >> "$GITHUB_ENV"
+
+      - name: Sign nested code, then the outer app
+        env:
+          KEYCHAIN: ${{ steps.developer_id_cert.outputs.keychain_path }}
+          APP_DIR: ${{ github.workspace }}/build/Pi Launcher.app
+        run: scripts/sign-app.sh
+
+      - name: Verify the signed app
+        run: scripts/verify-app.sh "$app_path" --signed
+
+      - name: Package for notarization
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/notary" && mkdir -p "$RUNNER_TEMP/notary"
+          cp -R "$app_path" "$RUNNER_TEMP/notary/$APP_NAME"
+          ditto -c -k --sequesterRsrc --keepParent "$RUNNER_TEMP/notary/$APP_NAME" "$RUNNER_TEMP/notary/notarize.zip"
+          echo "notary_zip=$RUNNER_TEMP/notary/notarize.zip" >> "$GITHUB_ENV"
+
+      - name: Notarize
+        env:
+          APPLE_API_KEY: ${{ steps.asc-key.outputs.key_path }}
+          APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          xcrun notarytool submit "$notary_zip" \
+            --key "$APPLE_API_KEY" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+
+      - name: Staple and build the distribution zip
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+          ZIP_NAME: ${{ steps.version.outputs.zip_name }}
+        run: |
+          set -euo pipefail
+          xcrun stapler staple "$app_path"
+          rm -rf "$RUNNER_TEMP/dist" && mkdir -p "$RUNNER_TEMP/dist"
+          cp -R "$app_path" "$RUNNER_TEMP/dist/$APP_NAME"
+          ditto -c -k --sequesterRsrc --keepParent "$RUNNER_TEMP/dist/$APP_NAME" "$RUNNER_TEMP/dist/$ZIP_NAME"
+          echo "dist_zip=$RUNNER_TEMP/dist/$ZIP_NAME" >> "$GITHUB_ENV"
+
+      - name: Verify the publication-ready artifact
+        # Fresh extraction of the exact zip that will be published: signature,
+        # identity, hardened runtime, notarization ticket, Gatekeeper.
+        run: |
+          set -euo pipefail
+          EXTRACT_DIR="$RUNNER_TEMP/final-verify"
+          rm -rf "$EXTRACT_DIR" && mkdir -p "$EXTRACT_DIR"
+          ditto -x -k "$dist_zip" "$EXTRACT_DIR"
+          scripts/verify-app.sh "$EXTRACT_DIR/$APP_NAME" --signed --gatekeeper
+
+      - name: Compute artifact checksum
+        env:
+          ZIP_NAME: ${{ steps.version.outputs.zip_name }}
+        run: |
+          set -euo pipefail
+          (cd "$(dirname "$dist_zip")" && shasum -a 256 "$ZIP_NAME" | tee "$ZIP_NAME.sha256")
+          cat "$dist_zip.sha256"
+
+      - name: Publish the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.version.outputs.tag_name }}
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+          ZIP_NAME: ${{ steps.version.outputs.zip_name }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release create "$TAG_NAME" \
+              --title "pi-launcher $RELEASE_VERSION" \
+              --notes "Signed, notarized Pi Launcher $RELEASE_VERSION. Bundles the official Pi $pi_version standalone (pinned in packaging/pi-release.json). See README.md for verification and install instructions."
+          fi
+          gh release upload "$TAG_NAME" --clobber "$dist_zip" "$dist_zip.sha256"
+
+      - name: Verify the published artifact
+        # Download exactly what users and Homebrew will get, and re-run the
+        # full gate against it. A release that only verifies intermediates is
+        # not a verified release.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.version.outputs.tag_name }}
+          ZIP_NAME: ${{ steps.version.outputs.zip_name }}
+        run: |
+          set -euo pipefail
+          DOWNLOAD_DIR="$RUNNER_TEMP/downloaded-verify"
+          rm -rf "$DOWNLOAD_DIR" && mkdir -p "$DOWNLOAD_DIR"
+          gh release download "$TAG_NAME" --pattern "$ZIP_NAME" --pattern "$ZIP_NAME.sha256" --dir "$DOWNLOAD_DIR" --clobber
+          (cd "$DOWNLOAD_DIR" && shasum -a 256 -c "$ZIP_NAME.sha256")
+          LOCAL_SHA="$(shasum -a 256 "$dist_zip" | awk '{print $1}')"
+          PUBLISHED_SHA="$(shasum -a 256 "$DOWNLOAD_DIR/$ZIP_NAME" | awk '{print $1}')"
+          if [ "$LOCAL_SHA" != "$PUBLISHED_SHA" ]; then
+            echo "Published artifact sha256 $PUBLISHED_SHA does not match the verified zip $LOCAL_SHA" >&2
+            exit 1
+          fi
+          EXTRACT_DIR="$RUNNER_TEMP/downloaded-extract"
+          mkdir -p "$EXTRACT_DIR"
+          ditto -x -k "$DOWNLOAD_DIR/$ZIP_NAME" "$EXTRACT_DIR"
+          scripts/verify-app.sh "$EXTRACT_DIR/$APP_NAME" --signed --gatekeeper
+          echo "Published artifact verified: $ZIP_NAME ($PUBLISHED_SHA)"
+
+      - name: Remove the signing keychain
+        if: always()
+        continue-on-error: true
+        run: security delete-keychain "${{ steps.developer_id_cert.outputs.keychain_path }}" || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.baseline/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+pi-launcher: a minimal signed macOS app whose executable spawns the one bundled official Pi CLI and stays alive as its parent in the caller's existing terminal. The whole product is a security boundary plus terminal transparency; both are enforced by tests, not by convention.
+
+## Invariants (do not weaken)
+
+- **Fixed target**: the launcher may only exec `Contents/Resources/pi/pi` inside its own bundle. Never add a target option, PATH/env resolution, a config file, or a shell. Negative tests in `tests/functional.py` guard this.
+- **Transparency**: fork+exec (never bare `exec`), same session/process group/controlling TTY, no PTY, no daemonization. Keyboard/job-control signals reach Pi via the group and are never forwarded (no duplicates); only signals directed at the launcher pid (HUP/TERM/USR1/USR2) are relayed, once. Pi exit codes pass through; Pi signal deaths are re-raised so the caller sees the identical wait status.
+- **Why same-group works for Ctrl-Z**: Pi's suspend is `process.kill(0, "SIGTSTP")` (see upstream `interactive-mode.js`), a group-wide stop, and the shell's `fg` continues the group. The launcher keeps default stop dispositions and does not use `waitpid(WUNTRACED)`; adding stop-relay machinery here reintroduces a stop/continue race - don't.
+- **Entitlements**: launcher has none; bundled Pi has exactly `allow-jit` (JavaScriptCore). `scripts/verify-app.sh` enforces both.
+- **Provenance**: bundled Pi is pinned in `packaging/pi-release.json` (version, URLs, sha256, upstream license sha256) and cross-checked against upstream `SHA256SUMS` on every fetch. Bump it in its own PR.
+
+## Layout and commands
+
+- `src/pi-launcher.c` - the entire launcher. Header comment documents the signal contract.
+- `tests/probe.c` + `tests/functional.py` + `tests/pty_tests.py` - probe-payload test double driven through real PTYs; `make test` runs everything including the bundled-Pi smoke.
+- `scripts/` - fetch/build/sign/verify pipeline; `check-release-contract.py` is the secret-free CI gate for workflow/packaging changes.
+- `.github/workflows/` - `ci.yml` (PR tests, no secrets), `release.yml` (tag-based signed/notarized release; canonical secret names documented in `RELEASE.md`).
+- `homebrew/pi-launcher.rb` - cask contract for the separate tap task; never publish from this repo.
+- Team ID `9T2J7MNUP9`, bundle id `com.kunchenguid.pi-launcher`, app `Pi Launcher.app`, asset `Pi-Launcher-<version>.zip`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Issues and PRs are welcome. A few ground rules that keep this project what it is:
+
+- **The fixed-target boundary is not negotiable.** The launcher will never gain a target option, PATH resolution, an environment override, a config file, or a shell. PRs that add any way to run something other than the one bundled Pi will be closed. If you need a general launcher, fork - the code is tiny.
+- **Terminal transparency is the product.** Any change to `src/pi-launcher.c` must keep the full test suite green (`make test`) and should come with a new test if it touches process, signal, or terminal behavior.
+- **No new dependencies.** The launcher is one C file against libSystem. The build is `clang`, `codesign`, `ditto`, and POSIX shell. Tests are C + Python 3 stdlib. Keep it that way.
+- **Signing is release-only.** Local development builds are ad-hoc signed and need no Apple credentials. Do not commit certificates, keychains, provisioning profiles, or notarization responses; CI scans for key material.
+
+## Workflow
+
+1. Fork and branch.
+2. `make test` must pass on macOS arm64 (this builds the unsigned dev app and runs the functional + PTY + smoke suites).
+3. `python3 scripts/check-release-contract.py` must pass if you touch packaging, workflows, or the cask template.
+4. Open the PR. CI runs the same suite on macos-26 without any signing secret.
+
+To bump the bundled Pi version: update `packaging/pi-release.json` (version, tag, URLs, both checksums) in its own PR, and say why the new upstream version is worth shipping.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+MIT License
+
+Copyright (c) 2026 Kun Chen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This repository builds an app that bundles Pi, a separate project by Mario
+Zechner (earendil-works), also MIT licensed. Pi's license ships inside the
+app at Contents/Resources/pi/LICENSE, and packaging/THIRD-PARTY-NOTICES.md
+covers attribution. This license covers only pi-launcher itself.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+SHELL := /bin/bash
+
+APP := build/Pi Launcher.app
+TEST_APP := build/TestPiLauncher.app
+LAUNCHER_EXE := $(APP)/Contents/MacOS/pi-launcher
+TEST_LAUNCHER_EXE := $(TEST_APP)/Contents/MacOS/pi-launcher
+PI_VERSION := $(shell python3 -c "import json; print(json.load(open('packaging/pi-release.json'))['version'])")
+
+.PHONY: all fetch app test-app test test-functional test-pty test-smoke verify clean
+
+all: app
+
+fetch:
+	scripts/fetch-pi.sh
+
+app: fetch
+	scripts/build-app.sh
+
+# Test app: same bundle shape, but Contents/Resources/pi/pi is the probe
+# binary instead of Pi. The launcher under test cannot tell the
+# difference - that is the point.
+test-app:
+	mkdir -p build
+	clang -O2 -std=c11 -Wall -Wextra -Wpedantic -Werror \
+	  -arch arm64 -mmacosx-version-min=13.0 \
+	  -o build/probe tests/probe.c
+	mkdir -p build/test-payload
+	cp build/probe build/test-payload/pi
+	chmod 755 build/test-payload/pi
+	printf 'Test payload placeholder license (real bundles ship the upstream Pi MIT license).\n' > build/test-payload/LICENSE
+	VERSION=0.0.0-test \
+	  PAYLOAD_DIR="$(CURDIR)/build/test-payload" \
+	  APP_DIR="$(CURDIR)/$(TEST_APP)" \
+	  scripts/build-app.sh
+
+test: test-functional test-pty test-smoke
+
+test-functional: test-app
+	python3 tests/functional.py "$(TEST_LAUNCHER_EXE)"
+
+test-pty: test-app
+	python3 tests/pty_tests.py "$(TEST_LAUNCHER_EXE)"
+
+# The real bundled Pi, driven through the real launcher: proves the
+# packaged app actually boots Pi, loads its themes, and passes argv.
+test-smoke: app
+	[[ "$$("$(LAUNCHER_EXE)" --version)" == "$(PI_VERSION)" ]]
+	"$(LAUNCHER_EXE)" -p --model invalid/model "say hi" 2>&1 | \
+	  grep -q 'Model "invalid/model" not found'
+	scripts/verify-app.sh "$(APP)"
+	@echo "test-smoke: bundled Pi works through the launcher"
+
+verify: app
+	scripts/verify-app.sh "$(APP)"
+
+clean:
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,121 @@
+<h1 align="center">pi-launcher</h1>
+<p align="center">
+  <a href="https://github.com/kunchenguid/pi-launcher/actions/workflows/ci.yml"
+    ><img
+      alt="CI"
+      src="https://img.shields.io/github/actions/workflow/status/kunchenguid/pi-launcher/ci.yml?style=flat-square&label=ci"
+  /></a>
+  <a href="https://github.com/kunchenguid/pi-launcher/actions/workflows/release.yml"
+    ><img
+      alt="Release"
+      src="https://img.shields.io/github/actions/workflow/status/kunchenguid/pi-launcher/release.yml?style=flat-square&label=release"
+  /></a>
+  <a
+    href="https://img.shields.io/badge/platform-macOS%20arm64-blue?style=flat-square"
+    ><img
+      alt="Platform"
+      src="https://img.shields.io/badge/platform-macOS%20arm64-blue?style=flat-square"
+  /></a>
+  <a href="https://x.com/kunchenguid"
+    ><img
+      alt="X"
+      src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square"
+  /></a>
+  <a href="https://discord.gg/Wsy2NpnZDu"
+    ><img
+      alt="Discord"
+      src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord"
+  /></a>
+</p>
+
+<h3 align="center">Run Pi in your terminal under a stable, signed macOS app identity.</h3>
+
+The official [Pi](https://github.com/earendil-works/pi) standalone macOS binary ships ad-hoc signed: Gatekeeper rejects it, and any tool that binds trust to a code-signed app identity has nothing stable to attach to. In my setup that tool is [Automic Vault](https://www.automicvault.com), which approves credential access by walking the process ancestry and matching designated requirements. An ad-hoc `a.out` signature gives it a different cdhash on every build.
+
+pi-launcher is the smallest fix: a signed, notarized `Pi Launcher.app` whose only executable does one thing - spawn the one official Pi binary bundled inside the same app, then stay alive as its parent in your existing terminal. No GUI, no PTY, no new window. Your terminal session stays exactly as it was; the process ancestry gains a stable signed identity.
+
+- **One fixed target** - the bundled Pi is pinned by version, upstream URL, and SHA-256. No PATH lookup, no target flag, no shell, no environment override.
+- **Transparent terminal semantics** - same TTY, same process group, same session. Exit codes, signal deaths, Ctrl-C, Ctrl-Z/`fg`, and resize all behave like a direct `pi` run, verified by a real pseudo-terminal test suite.
+- **Auditable by design** - the launcher is one C file, ~250 lines, zero dependencies beyond libSystem. The app has no entitlements; the bundled Pi gets exactly one (`allow-jit`, because JavaScriptCore).
+
+## Quick Start
+
+```sh
+$ brew install --cask kunchenguid/tap/pi-launcher   # tap PR lands after first release
+$ pi-signed "review the diff on main"                # exactly like `pi`
+```
+
+Until the tap is published, download `Pi-Launcher-<version>.zip` from the [latest release](https://github.com/kunchenguid/pi-launcher/releases/latest), unzip, and move `Pi Launcher.app` to `/Applications`. Then run it:
+
+```sh
+$ /Applications/Pi\ Launcher.app/Contents/MacOS/pi-launcher -p "summarize this repo"
+```
+
+Add a shim if you want a short command (this never touches an existing `pi`):
+
+```sh
+$ ln -s "/Applications/Pi Launcher.app/Contents/MacOS/pi-launcher" ~/.local/bin/pi-signed
+```
+
+## How It Works
+
+```
+your shell (zsh)
+  └─ pi-launcher          <- signed app identity, stays alive as parent
+       └─ pi              <- the exact official binary bundled in the app
+            └─ bash, gh, ...   <- Pi's own children, unchanged
+```
+
+- **Fork + exec, not exec** - the launcher stays in the process chain as Pi's direct parent, so an ancestry-walking tool sees the signed app on every Pi child.
+- **Same process group** - the launcher does not create a new session, process group, or PTY. Keyboard signals go to the foreground group exactly like a direct run: Pi handles Ctrl-C, Pi's own Ctrl-Z stops the whole group (it literally calls `kill(0, SIGTSTP)`), and `fg` resumes both.
+- **No duplicate signals** - terminal-generated signals already reach Pi through the group, so the launcher never forwards those. It only forwards signals aimed at the launcher process itself (`SIGHUP`, `SIGTERM`, `SIGUSR1`, `SIGUSR2`), each exactly once, so killing the launcher can't orphan a live Pi.
+- **Exit status reproduced** - Pi's exit code passes through unchanged; if Pi dies by a signal, the launcher re-raises the same signal on itself, so `$?` and job notifications match a direct run.
+
+## CLI Reference
+
+There are no launcher flags. Every argument is passed to Pi byte-for-byte, including things that look like launcher options (`--target`, `--help`, whatever). See `pi --help` for Pi's own flags.
+
+| Invocation | What happens |
+| ---------- | ------------ |
+| `pi-signed [pi args...]` | Runs the bundled Pi with those args |
+| Exit code `0`-`255` | Pi's own exit code |
+| Exit code `126` | The bundled Pi inside the app is not executable (reinstall) |
+| Exit code `127` | The bundled Pi inside the app is missing (reinstall) |
+
+## Security Boundary
+
+- The launcher can execute exactly one file: `Contents/Resources/pi/pi` inside its own app bundle. There is no code path that resolves a command from `PATH`, from an environment variable, or from an argument. The test suite includes negative tests that try all three.
+- The bundled Pi is the official `pi-darwin-arm64.tar.gz` from [earendil-works/pi releases](https://github.com/earendil-works/pi/releases), pinned in `packaging/pi-release.json` and verified against both the pinned checksum and upstream's `SHA256SUMS` at build time. Its MIT license ships in the bundle.
+- Signing: Developer ID Application (Team `9T2J7MNUP9`), hardened runtime, secure timestamps, nested code signed inside-out, notarized, stapled. The launcher itself has zero entitlements.
+- This is a process wrapper, not a sandbox. Pi still runs with your full user permissions, same as always.
+
+## Limitations
+
+- macOS arm64 only (that's what upstream's standalone binary targets).
+- One pinned Pi version per pi-launcher release. Upgrading Pi means a new pi-launcher release; the app does not self-update.
+- Not an official Pi distribution. Pi is Mario Zechner's project; this is an independent wrapper. Report Pi behavior issues upstream, launcher issues here.
+- A signed parent is necessary but not sufficient for Automic Vault recognition: whether Automic binds policy to this app identity is still unproven until the attended live test runs. The identity exists; don't assume the policy match.
+
+## Verify a Release
+
+Every release publishes `Pi-Launcher-<version>.zip` and `Pi-Launcher-<version>.zip.sha256`. The release workflow verifies the exact published artifact after upload (signature, notarization, Gatekeeper); you can repeat all of it locally:
+
+```sh
+shasum -a 256 -c Pi-Launcher-<version>.zip.sha256
+unzip Pi-Launcher-<version>.zip
+spctl --assess --type execute -v "Pi Launcher.app"     # accepted, Notarized Developer ID
+xcrun stapler validate "Pi Launcher.app"               # ticket stapled
+codesign -d -r- "Pi Launcher.app"                      # DR: identifier + apple generic + Team 9T2J7MNUP9
+codesign -d --entitlements - "Pi Launcher.app/Contents/MacOS/pi-launcher"   # no entitlements
+```
+
+## Development
+
+```sh
+make fetch      # download + verify the pinned upstream Pi
+make app        # build the unsigned dev app
+make test       # functional + PTY + bundled-Pi smoke suites
+make clean
+```
+
+The test suite swaps a probe binary into the same bundle layout and drives the launcher through real pseudo-terminals: argv/env/cwd byte-exactness, stdio transparency, exit and signal reproduction, foreground process group, resize, Ctrl-C, Ctrl-Z/`fg`, and Pi-style group suspend, plus negative tests for the fixed-target boundary. Releases are tag-based; see [RELEASE.md](RELEASE.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,45 @@
+# pi-launcher release pipeline
+
+Releases are tag-based. Pushing a tag like `v1.2.3` (or dispatching `.github/workflows/release.yml` with a tag name) builds, signs, notarizes, staples, verifies, and publishes `Pi-Launcher-1.2.3.zip` plus `Pi-Launcher-1.2.3.zip.sha256` to the GitHub release for that tag.
+
+The pipeline stops at any failed gate: pinned-checksum or upstream `SHA256SUMS` mismatch, missing nested signature, wrong identity, wrong Team ID, wrong bundle ID, missing hardened runtime, missing secure timestamp, unexpected entitlements, notarization failure, stapling failure, Gatekeeper rejection, wrong architecture, or a mismatch between the verified zip and the published download. The last two verification steps run against the exact zip that users and Homebrew download, not an intermediate app.
+
+## One-time setup
+
+Use Apple Team `9T2J7MNUP9`. Reuse the existing **Developer ID Application** certificate (do not create a new one; Apple caps them per team) and the existing App Store Connect API key. Set exactly these repository secrets on `kunchenguid/pi-launcher`:
+
+```sh
+REPO=kunchenguid/pi-launcher
+base64 -i DeveloperID_Application.p12 | tr -d '\n' | gh secret set MAC_DEVELOPER_ID_CERT_P12 --repo "$REPO"
+printf '%s' 'THE_P12_PASSWORD' | gh secret set MAC_DEVELOPER_ID_CERT_PASSWORD --repo "$REPO"
+printf '%s' 'KEY_ID' | gh secret set APP_STORE_CONNECT_KEY_ID --repo "$REPO"
+printf '%s' 'ISSUER_ID' | gh secret set APP_STORE_CONNECT_ISSUER_ID --repo "$REPO"
+base64 -i "AuthKey_KEY_ID.p8" | gh secret set APP_STORE_CONNECT_API_KEY --repo "$REPO"
+```
+
+On GNU/Linux, use `base64 -w0` instead of `base64 -i`. Never commit the `.p12`, the `.p8`, or either password. The workflow decodes the p12 into a throwaway keychain on the runner and validates that it actually contains `Developer ID Application: Kun Chen (9T2J7MNUP9)` before signing anything.
+
+## Cut a release
+
+1. Merge everything that should ship. `main` must be green.
+2. Tag: `git tag v1.2.3 && git push origin v1.2.3` (or dispatch the workflow with the tag name).
+3. The workflow resolves the version from the tag, stamps it into the bundle, fetches and re-verifies the pinned upstream Pi, builds, signs inside-out, notarizes, staples, verifies the publication-ready zip, publishes, then downloads the published asset and verifies it again.
+4. If any step fails, do not retry blindly: the failure is the gate working. Fix the cause, re-tag.
+
+## Artifact contract (consumed by the Homebrew tap)
+
+- Asset: `Pi-Launcher-<version>.zip` containing exactly `Pi Launcher.app`.
+- Checksum sidecar: `Pi-Launcher-<version>.zip.sha256` in `shasum -a 256` format.
+- The app: bundle id `com.kunchenguid.pi-launcher`, executable `Contents/MacOS/pi-launcher`, LSUIElement, arm64, hardened runtime, notarized and stapled. Its designated requirement pins the identifier and Team ID.
+- The cask shape lives at `homebrew/pi-launcher.rb`. The tap task copies it into the captain's tap, sets `version` and `sha256` from the release, and chooses the shim target name (template suggests `pi-signed`; it must never shadow an existing `pi`).
+
+## Local validation without secrets
+
+Everything except signing and notarization runs locally:
+
+```sh
+make test                                 # full suite on the unsigned dev app
+python3 scripts/check-release-contract.py # release/config contracts
+```
+
+Signed and notarized builds require the certificate and API key above, which exist only as GitHub secrets.

--- a/homebrew/pi-launcher.rb
+++ b/homebrew/pi-launcher.rb
@@ -1,0 +1,25 @@
+# Homebrew cask for the captain's public tap (homebrew-tap).
+#
+# This file is the release metadata contract consumed by the later tap
+# task: copy it into the tap as Casks/pi-launcher.rb, set `version` to the
+# release tag without the "v", and set `sha256` from the release's
+# Pi-Launcher-<version>.zip.sha256 asset. This repo's release workflow
+# guarantees the artifact name, the .sha256 sidecar, and the app layout
+# below. Do not publish from this repository.
+cask "pi-launcher" do
+  version "0.0.0" # replace with the release version, e.g. "1.0.0"
+  sha256 "REPLACE_WITH_RELEASE_ZIP_SHA256"
+
+  url "https://github.com/kunchenguid/pi-launcher/releases/download/v#{version}/Pi-Launcher-#{version}.zip"
+  name "Pi Launcher"
+  desc "Signed, notarized macOS app that launches one bundled Pi CLI transparently in your terminal"
+  homepage "https://github.com/kunchenguid/pi-launcher"
+
+  # The app is agent-only (LSUIElement); the binary shim puts the launcher
+  # on PATH without touching any existing `pi` command.
+  app "Pi Launcher.app"
+  binary "#{appdir}/Pi Launcher.app/Contents/MacOS/pi-launcher", target: "pi-signed"
+
+  # No zap: the launcher writes nothing of its own, and Pi's own data in
+  # ~/.pi belongs to Pi, not to this cask.
+end

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>pi-launcher</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.kunchenguid.pi-launcher</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Pi Launcher</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>@VERSION@</string>
+	<key>CFBundleVersion</key>
+	<string>@VERSION@</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 Kun Chen. Pi is developed by Mario Zechner (MIT).</string>
+</dict>
+</plist>

--- a/packaging/THIRD-PARTY-NOTICES.md
+++ b/packaging/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,17 @@
+# Third-Party Notices
+
+## Pi
+
+This application bundles an unmodified copy of **Pi**, the terminal coding
+agent by Mario Zechner / earendil-works, obtained from the official release
+channel at <https://github.com/earendil-works/pi>.
+
+- Bundled version: see `packaging/pi-release.json` in
+  <https://github.com/kunchenguid/pi-launcher> (pinned by version, URL, and
+  SHA-256 checksum).
+- License: MIT, Copyright (c) 2025 Mario Zechner. The full license text
+  ships inside this bundle at `Contents/Resources/pi/LICENSE`.
+
+Pi Launcher is an independent wrapper and is **not** an official Pi
+distribution. Pi itself remains the work of its own authors; all questions
+about Pi's behavior belong upstream.

--- a/packaging/pi-entitlements.plist
+++ b/packaging/pi-entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+		Entitlements for the bundled Pi executable only (never for the
+		launcher itself). Pi is a Bun-compiled JavaScriptCore runtime; the
+		hardened runtime blocks MAP_JIT without this, which would silently
+		degrade every Pi session to interpreter speed. This is the only
+		entitlement in the whole bundle.
+	-->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>

--- a/packaging/pi-release.json
+++ b/packaging/pi-release.json
@@ -1,0 +1,10 @@
+{
+  "upstream": "https://github.com/earendil-works/pi",
+  "tag": "v0.82.0",
+  "version": "0.82.0",
+  "url": "https://github.com/earendil-works/pi/releases/download/v0.82.0/pi-darwin-arm64.tar.gz",
+  "sha256": "6205debd0071ff56d765e0ee941f087f9a18d1f6c2f7dea17bdc8f97ff3cf9c1",
+  "sumsUrl": "https://github.com/earendil-works/pi/releases/download/v0.82.0/SHA256SUMS",
+  "licenseUrl": "https://raw.githubusercontent.com/earendil-works/pi/v0.82.0/LICENSE",
+  "licenseSha256": "0457f5bcec3b3b211605dfb5d1a49042fd638f3686a410fe099c24a25af13c48"
+}

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# build-app.sh - compile the launcher and assemble "Pi Launcher.app".
+#
+# The result is an unsigned development app (ad-hoc signed so it runs on
+# Apple Silicon). Release signing lives in sign-app.sh.
+#
+# Environment:
+#   VERSION        - app version stamped into Info.plist (default 0.0.0-dev)
+#   PAYLOAD_DIR    - directory whose contents become Contents/Resources/pi
+#                    (default: build/vendor/pi-tree/pi from fetch-pi.sh)
+#   APP_DIR        - output app path (default: build/Pi Launcher.app)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${VERSION:-0.0.0-dev}"
+PAYLOAD_DIR="${PAYLOAD_DIR:-$REPO_ROOT/build/vendor/pi-tree/pi}"
+APP_DIR="${APP_DIR:-$REPO_ROOT/build/Pi Launcher.app}"
+LAUNCHER_BIN="$REPO_ROOT/build/pi-launcher"
+
+if [[ ! -x "$PAYLOAD_DIR/pi" ]]; then
+  echo "build-app: FAIL: payload $PAYLOAD_DIR has no executable pi (run scripts/fetch-pi.sh first)" >&2
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/build"
+
+clang \
+  -O2 -std=c11 -Wall -Wextra -Wpedantic -Werror \
+  -arch arm64 -mmacosx-version-min=13.0 \
+  -o "$LAUNCHER_BIN" \
+  "$REPO_ROOT/src/pi-launcher.c"
+
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources"
+
+sed "s/@VERSION@/$VERSION/g" "$REPO_ROOT/packaging/Info.plist" > "$APP_DIR/Contents/Info.plist"
+plutil -lint "$APP_DIR/Contents/Info.plist" >/dev/null
+
+cp "$LAUNCHER_BIN" "$APP_DIR/Contents/MacOS/pi-launcher"
+chmod 755 "$APP_DIR/Contents/MacOS/pi-launcher"
+
+# The payload is copied, never linked: the shipped app must be a
+# self-contained bundle.
+rm -rf "$APP_DIR/Contents/Resources/pi"
+cp -R "$PAYLOAD_DIR" "$APP_DIR/Contents/Resources/pi"
+cp "$REPO_ROOT/packaging/THIRD-PARTY-NOTICES.md" "$APP_DIR/Contents/Resources/THIRD-PARTY-NOTICES.md"
+
+# Ad-hoc sign nested code first, then the outer bundle, so the development
+# app is coherent and runnable on Apple Silicon. Release builds re-sign
+# everything with the Developer ID identity inside-out, same order.
+find "$APP_DIR/Contents/Resources" -type f -print0 | while IFS= read -r -d '' f; do
+  if file -b "$f" | grep -q "^Mach-O"; then
+    codesign --force --sign - "$f" >/dev/null
+  fi
+done
+codesign --force --sign - "$APP_DIR" >/dev/null
+
+echo "build-app: assembled $APP_DIR (version $VERSION)"

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+check-release-contract.py - CI gate that validates the release pipeline and
+packaging contracts without needing any signing secret.
+
+Checks, in order:
+  1. packaging/pi-release.json schema, pinning, and URL hygiene
+  2. upstream SHA256SUMS still matches the pinned checksum (supply chain)
+  3. .github/workflows/release.yml has every required gate, in order
+  4. release.yml references exactly the canonical secret names
+  5. release.yml pins the canonical Team ID and bundle ID
+  6. .github/workflows/ci.yml runs the test suite on pull requests
+  7. homebrew/pi-launcher.rb matches the release artifact contract
+  8. no private key material anywhere in the tracked tree
+"""
+
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FAILURES = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"PASS {name}")
+    else:
+        FAILURES.append(name)
+        print(f"FAIL {name} {detail}")
+
+
+# ---- 1. pi-release.json ----
+manifest = json.loads((ROOT / "packaging/pi-release.json").read_text())
+required_keys = {
+    "upstream",
+    "tag",
+    "version",
+    "url",
+    "sha256",
+    "sumsUrl",
+    "licenseUrl",
+    "licenseSha256",
+}
+check(
+    "pi-release.json has all required keys",
+    required_keys <= set(manifest),
+    f"missing: {required_keys - set(manifest)}",
+)
+check(
+    "pi-release.json pins a 64-hex sha256",
+    re.fullmatch(r"[0-9a-f]{64}", manifest.get("sha256", "")) is not None
+    and re.fullmatch(r"[0-9a-f]{64}", manifest.get("licenseSha256", "")) is not None,
+)
+upstream = "https://github.com/earendil-works/pi"
+check(
+    "pi-release.json URLs are https and upstream-pinned",
+    manifest.get("upstream") == upstream
+    and manifest.get("url", "").startswith(upstream + "/releases/download/")
+    and manifest.get("sumsUrl", "").startswith(upstream + "/releases/download/")
+    and manifest.get("licenseUrl", "").startswith(
+        "https://raw.githubusercontent.com/earendil-works/pi/"
+    ),
+)
+check(
+    "pi-release.json tag/version consistency",
+    manifest.get("tag") == "v" + manifest.get("version", "\x00")
+    and manifest.get("tag", "") in manifest.get("url", "")
+    and manifest.get("tag", "") in manifest.get("licenseUrl", "")
+    and manifest.get("tag", "") in manifest.get("sumsUrl", ""),
+)
+
+# ---- 2. upstream SHA256SUMS cross-check ----
+try:
+    with urllib.request.urlopen(manifest["sumsUrl"], timeout=30) as resp:
+        sums = resp.read().decode()
+    entry = next(
+        (
+            line.split()[0]
+            for line in sums.splitlines()
+            if line.split()[-1] == "pi-darwin-arm64.tar.gz"
+        ),
+        None,
+    )
+    check(
+        "upstream SHA256SUMS matches the pinned checksum",
+        entry == manifest["sha256"],
+        f"upstream={entry} pinned={manifest['sha256']}",
+    )
+except Exception as exc:  # network failure must not silently pass
+    check("upstream SHA256SUMS matches the pinned checksum", False, repr(exc))
+
+# ---- 3. release.yml gates, in order ----
+release_yml = (ROOT / ".github/workflows/release.yml").read_text()
+required_sequence = [
+    "scripts/fetch-pi.sh",
+    "scripts/build-app.sh",
+    "scripts/sign-app.sh",
+    '--signed',
+    "notarytool submit",
+    "stapler staple",
+    "--signed --gatekeeper",
+    "gh release create",
+    "gh release upload",
+    "gh release download",
+    "shasum -a 256 -c",
+]
+positions = []
+for token in required_sequence:
+    pos = release_yml.find(token)
+    if pos < 0:
+        break
+    positions.append(pos)
+check(
+    "release.yml has every required gate in order",
+    len(positions) == len(required_sequence)
+    and positions == sorted(positions),
+    f"found {len(positions)}/{len(required_sequence)} tokens, ordered={positions == sorted(positions)}",
+)
+for token in (
+    "Verify the publication-ready artifact",
+    "Verify the published artifact",
+    "runs-on: macos-26",
+):
+    check(f"release.yml contains '{token}'", token in release_yml)
+
+# ---- 4. canonical secrets only ----
+referenced = set(re.findall(r"secrets\.([A-Z0-9_]+)", release_yml))
+canonical = {
+    "APP_STORE_CONNECT_KEY_ID",
+    "APP_STORE_CONNECT_ISSUER_ID",
+    "APP_STORE_CONNECT_API_KEY",
+    "MAC_DEVELOPER_ID_CERT_P12",
+    "MAC_DEVELOPER_ID_CERT_PASSWORD",
+    "GITHUB_TOKEN",
+}
+check(
+    "release.yml references exactly the canonical secrets",
+    referenced == canonical,
+    f"referenced={sorted(referenced)}",
+)
+
+# ---- 5. pinned identity ----
+check(
+    "release.yml pins Team ID, bundle ID, and Developer ID identity",
+    "TEAM_ID: 9T2J7MNUP9" in release_yml
+    and "BUNDLE_ID: com.kunchenguid.pi-launcher" in release_yml
+    and "Developer ID Application: Kun Chen (9T2J7MNUP9)" in release_yml,
+)
+
+# ---- 6. ci.yml runs tests on PRs without secrets ----
+ci_yml = (ROOT / ".github/workflows/ci.yml").read_text()
+check(
+    "ci.yml runs the full test suite on pull_request",
+    "pull_request:" in ci_yml
+    and "make test-functional" in ci_yml
+    and "make test-pty" in ci_yml
+    and "make test-smoke" in ci_yml,
+)
+check(
+    "ci.yml does not reference signing secrets",
+    "MAC_DEVELOPER_ID" not in ci_yml and "APP_STORE_CONNECT" not in ci_yml,
+)
+
+# ---- 7. Homebrew cask template matches the release contract ----
+cask = (ROOT / "homebrew/pi-launcher.rb").read_text()
+check(
+    "cask url matches the release asset naming",
+    "https://github.com/kunchenguid/pi-launcher/releases/download/v#{version}/Pi-Launcher-#{version}.zip"
+    in cask,
+)
+check(
+    "cask installs the app and a binary shim",
+    'app "Pi Launcher.app"' in cask
+    and 'binary "#{appdir}/Pi Launcher.app/Contents/MacOS/pi-launcher"' in cask,
+)
+check(
+    "cask sha256 is a placeholder for the tap task",
+    'sha256 "REPLACE_WITH_RELEASE_ZIP_SHA256"' in cask,
+)
+
+# ---- 8. no private key material in the tree ----
+tracked = subprocess.run(
+    ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True
+).stdout.split()
+leaks = []
+for name in tracked:
+    path = ROOT / name
+    if not path.is_file() or path.stat().st_size > 5_000_000:
+        continue
+    try:
+        text = path.read_text(errors="strict")
+    except (UnicodeDecodeError, ValueError):
+        continue
+    needle = "PRIVATE KEY" + "-----"
+    if needle in text:
+        leaks.append(name)
+check("no private key material tracked", not leaks, f"leaks={leaks}")
+
+print()
+if FAILURES:
+    print(f"contract: {len(FAILURES)} FAILED")
+    sys.exit(1)
+print("contract: all checks passed")

--- a/scripts/fetch-pi.sh
+++ b/scripts/fetch-pi.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# fetch-pi.sh - download and verify the pinned upstream Pi release.
+#
+# Provenance gate: the tarball must match BOTH the checksum pinned in
+# packaging/pi-release.json AND the SHA256SUMS entry published on the
+# upstream release. Any mismatch stops the build.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="$REPO_ROOT/packaging/pi-release.json"
+VENDOR_DIR="$REPO_ROOT/build/vendor"
+TREE_DIR="$VENDOR_DIR/pi-tree"
+
+read_manifest() {
+  python3 - "$MANIFEST" "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    print(json.load(f)[sys.argv[2]])
+PY
+}
+
+URL="$(read_manifest url)"
+EXPECTED_SHA256="$(read_manifest sha256)"
+SUMS_URL="$(read_manifest sumsUrl)"
+LICENSE_URL="$(read_manifest licenseUrl)"
+EXPECTED_LICENSE_SHA256="$(read_manifest licenseSha256)"
+VERSION="$(read_manifest version)"
+
+TARBALL="$VENDOR_DIR/pi-darwin-arm64.tar.gz"
+SUMS_FILE="$VENDOR_DIR/SHA256SUMS"
+LICENSE_FILE="$VENDOR_DIR/LICENSE.upstream"
+
+mkdir -p "$VENDOR_DIR"
+
+sha256_of() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+download() {
+  local url="$1" out="$2"
+  echo "fetch-pi: downloading $url"
+  curl -fsSL --retry 3 -o "$out" "$url"
+}
+
+if [[ ! -f "$TARBALL" ]] || [[ "$(sha256_of "$TARBALL")" != "$EXPECTED_SHA256" ]]; then
+  download "$URL" "$TARBALL"
+fi
+if [[ ! -f "$SUMS_FILE" ]]; then
+  download "$SUMS_URL" "$SUMS_FILE"
+fi
+if [[ ! -f "$LICENSE_FILE" ]] || [[ "$(sha256_of "$LICENSE_FILE")" != "$EXPECTED_LICENSE_SHA256" ]]; then
+  download "$LICENSE_URL" "$LICENSE_FILE"
+fi
+
+ACTUAL_SHA256="$(sha256_of "$TARBALL")"
+if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+  echo "fetch-pi: FAIL: tarball sha256 $ACTUAL_SHA256 does not match pinned $EXPECTED_SHA256" >&2
+  exit 1
+fi
+
+SUMS_ENTRY="$(awk -v f="pi-darwin-arm64.tar.gz" '$2 == f {print $1}' "$SUMS_FILE")"
+if [[ -z "$SUMS_ENTRY" ]]; then
+  echo "fetch-pi: FAIL: upstream SHA256SUMS has no pi-darwin-arm64.tar.gz entry" >&2
+  exit 1
+fi
+if [[ "$SUMS_ENTRY" != "$EXPECTED_SHA256" ]]; then
+  echo "fetch-pi: FAIL: upstream SHA256SUMS entry $SUMS_ENTRY does not match pinned $EXPECTED_SHA256" >&2
+  exit 1
+fi
+
+ACTUAL_LICENSE_SHA256="$(sha256_of "$LICENSE_FILE")"
+if [[ "$ACTUAL_LICENSE_SHA256" != "$EXPECTED_LICENSE_SHA256" ]]; then
+  echo "fetch-pi: FAIL: upstream LICENSE sha256 mismatch" >&2
+  exit 1
+fi
+
+rm -rf "$TREE_DIR"
+mkdir -p "$TREE_DIR"
+tar xzf "$TARBALL" -C "$TREE_DIR"
+# The tarball contains a top-level pi/ directory holding the standalone
+# binary and its runtime resources; the whole tree ships inside the app.
+if [[ ! -x "$TREE_DIR/pi/pi" ]]; then
+  echo "fetch-pi: FAIL: extracted tree has no executable pi/pi" >&2
+  exit 1
+fi
+cp "$LICENSE_FILE" "$TREE_DIR/pi/LICENSE"
+
+echo "fetch-pi: verified pi $VERSION ($ACTUAL_SHA256)"

--- a/scripts/sign-app.sh
+++ b/scripts/sign-app.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# sign-app.sh - sign "Pi Launcher.app" with the Developer ID identity.
+#
+# Inside-out order, required by both Apple and this repo's release gate:
+#   1. every nested Mach-O under Contents/Resources (dylibs, .node, pi)
+#   2. the launcher main executable
+#   3. the outer app bundle
+#
+# All code gets the hardened runtime and a secure timestamp. The bundled
+# Pi executable is the only file that carries an entitlement (allow-jit;
+# see packaging/pi-entitlements.plist). The launcher itself ships with
+# zero entitlements.
+#
+# Environment:
+#   APP_DIR       - app to sign (default: build/Pi Launcher.app)
+#   SIGN_IDENTITY - codesign identity (default: the canonical Developer ID)
+#   KEYCHAIN      - optional keychain file to pass to codesign --keychain
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="${APP_DIR:-$REPO_ROOT/build/Pi Launcher.app}"
+SIGN_IDENTITY="${SIGN_IDENTITY:-Developer ID Application: Kun Chen (9T2J7MNUP9)}"
+PI_ENTITLEMENTS="$REPO_ROOT/packaging/pi-entitlements.plist"
+
+KEYCHAIN_ARGS=()
+if [[ -n "${KEYCHAIN:-}" ]]; then
+  KEYCHAIN_ARGS=(--keychain "$KEYCHAIN")
+fi
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "sign-app: FAIL: no app at $APP_DIR" >&2
+  exit 1
+fi
+
+sign_one() {
+  local path="$1"
+  shift
+  echo "sign-app: signing $path"
+  codesign --force --sign "$SIGN_IDENTITY" \
+    --options runtime --timestamp \
+    "${KEYCHAIN_ARGS[@]}" \
+    "$@" "$path" >/dev/null
+}
+
+# 1. Nested code, deepest paths first. The bundled Pi executable gets the
+#    JIT entitlement; every other nested binary gets none.
+PI_BINARY="$APP_DIR/Contents/Resources/pi/pi"
+NESTED_LIST="$(mktemp)"
+trap 'rm -f "$NESTED_LIST"' EXIT
+find "$APP_DIR/Contents/Resources" -type f -print0 |
+  while IFS= read -r -d '' f; do
+    if file -b "$f" | grep -q "^Mach-O"; then
+      printf '%s\n' "$f"
+    fi
+  done | awk '{ print length($0), $0 }' | sort -rn | cut -d' ' -f2- > "$NESTED_LIST"
+if [[ ! -s "$NESTED_LIST" ]]; then
+  echo "sign-app: FAIL: no nested Mach-O found under $APP_DIR/Contents/Resources" >&2
+  exit 1
+fi
+FOUND_PI=0
+while IFS= read -r f; do
+  if [[ "$f" == "$PI_BINARY" ]]; then
+    FOUND_PI=1
+    sign_one "$f" --entitlements "$PI_ENTITLEMENTS"
+  else
+    sign_one "$f"
+  fi
+done < "$NESTED_LIST"
+if [[ "$FOUND_PI" -ne 1 ]]; then
+  echo "sign-app: FAIL: bundled Pi binary missing at $PI_BINARY" >&2
+  exit 1
+fi
+
+# 2. Main executable, no entitlements.
+sign_one "$APP_DIR/Contents/MacOS/pi-launcher"
+
+# 3. Outer bundle (seals everything signed above).
+sign_one "$APP_DIR"
+
+echo "sign-app: signed $APP_DIR with '$SIGN_IDENTITY'"

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# verify-app.sh - release gate: verify structure, signatures, identity,
+# hardening, and (optionally) Gatekeeper acceptance of "Pi Launcher.app".
+#
+# Modes:
+#   verify-app.sh <app>                 structural + ad-hoc-safe checks (CI on PRs)
+#   verify-app.sh <app> --signed        additionally require Developer ID identity,
+#                                       hardened runtime, Team ID, entitlements
+#   verify-app.sh <app> --signed --gatekeeper
+#                                       additionally require a stapled notarization
+#                                       ticket and spctl acceptance
+#
+# Every failed check stops the release. There is no warn-only path.
+set -euo pipefail
+
+APP_DIR="${1:-}"
+MODE_SIGNED=0
+MODE_GATEKEEPER=0
+for arg in "${@:2}"; do
+  case "$arg" in
+    --signed) MODE_SIGNED=1 ;;
+    --gatekeeper) MODE_GATEKEEPER=1 ;;
+    *) echo "verify-app: FAIL: unknown argument $arg" >&2; exit 1 ;;
+  esac
+done
+if [[ "$MODE_GATEKEEPER" -eq 1 ]]; then
+  MODE_SIGNED=1
+fi
+
+EXPECTED_BUNDLE_ID="com.kunchenguid.pi-launcher"
+EXPECTED_TEAM_ID="9T2J7MNUP9"
+EXPECTED_EXECUTABLE="pi-launcher"
+
+fail() {
+  echo "verify-app: FAIL: $1" >&2
+  exit 1
+}
+
+[[ -n "$APP_DIR" ]] || fail "usage: verify-app.sh <app> [--signed] [--gatekeeper]"
+[[ -d "$APP_DIR" ]] || fail "no app at $APP_DIR"
+
+plist_get() {
+  /usr/libexec/PlistBuddy -c "Print :$1" "$APP_DIR/Contents/Info.plist" 2>/dev/null || true
+}
+
+# ---- Structure ----
+[[ "$(plist_get CFBundleIdentifier)" == "$EXPECTED_BUNDLE_ID" ]] \
+  || fail "CFBundleIdentifier is '$(plist_get CFBundleIdentifier)', expected $EXPECTED_BUNDLE_ID"
+[[ "$(plist_get CFBundleExecutable)" == "$EXPECTED_EXECUTABLE" ]] \
+  || fail "CFBundleExecutable mismatch"
+[[ "$(plist_get CFBundlePackageType)" == "APPL" ]] \
+  || fail "CFBundlePackageType is not APPL"
+[[ "$(plist_get LSUIElement)" == "true" ]] \
+  || fail "LSUIElement must be true (agent app, no Dock presence)"
+[[ -x "$APP_DIR/Contents/MacOS/pi-launcher" ]] \
+  || fail "main executable missing or not executable"
+[[ -x "$APP_DIR/Contents/Resources/pi/pi" ]] \
+  || fail "bundled Pi missing or not executable"
+[[ -f "$APP_DIR/Contents/Resources/pi/LICENSE" ]] \
+  || fail "upstream MIT LICENSE missing from bundle"
+[[ -f "$APP_DIR/Contents/Resources/THIRD-PARTY-NOTICES.md" ]] \
+  || fail "THIRD-PARTY-NOTICES.md missing from bundle"
+
+# ---- Architecture: every Mach-O in the bundle must be arm64 ----
+MACH_O_COUNT=0
+while IFS= read -r -d '' f; do
+  if file -b "$f" | grep -q "^Mach-O"; then
+    MACH_O_COUNT=$((MACH_O_COUNT + 1))
+    file -b "$f" | grep -q "arm64" \
+      || fail "non-arm64 Mach-O in bundle: $f ($(file -b "$f"))"
+  fi
+done < <(find "$APP_DIR" -type f -print0)
+[[ "$MACH_O_COUNT" -ge 2 ]] \
+  || fail "expected at least 2 Mach-O files (launcher, payload), found $MACH_O_COUNT"
+
+# ---- Version fields must agree ----
+SHORT_VERSION="$(plist_get CFBundleShortVersionString)"
+BUNDLE_VERSION="$(plist_get CFBundleVersion)"
+[[ -n "$SHORT_VERSION" && "$SHORT_VERSION" == "$BUNDLE_VERSION" ]] \
+  || fail "CFBundleShortVersionString ($SHORT_VERSION) != CFBundleVersion ($BUNDLE_VERSION)"
+
+echo "verify-app: structure OK ($MACH_O_COUNT Mach-O files, version $SHORT_VERSION)"
+
+if [[ "$MODE_SIGNED" -eq 0 ]]; then
+  exit 0
+fi
+
+# ---- Signature validity (all nested code + outer seal) ----
+codesign --verify --deep --strict --verbose=2 "$APP_DIR" 2>&1 \
+  || fail "codesign --verify --deep --strict failed"
+
+# ---- Identity, Team ID, hardened runtime, entitlements on every Mach-O ----
+LAUNCHER_ENTITLEMENTS_XML="$(mktemp)"
+PI_ENTITLEMENTS_XML="$(mktemp)"
+trap 'rm -f "$LAUNCHER_ENTITLEMENTS_XML" "$PI_ENTITLEMENTS_XML"' EXIT
+
+while IFS= read -r -d '' f; do
+  file -b "$f" | grep -q "^Mach-O" || continue
+  INFO="$(codesign -dvvv "$f" 2>&1)" \
+    || fail "codesign -dvvv failed on $f"
+  echo "$INFO" | grep -q "^Authority=Developer ID Application: Kun Chen ($EXPECTED_TEAM_ID)$" \
+    || fail "$f not signed by the expected Developer ID identity"
+  echo "$INFO" | grep -q "^TeamIdentifier=$EXPECTED_TEAM_ID$" \
+    || fail "$f has wrong Team ID"
+  echo "$INFO" | grep -q "flags=0x10000(runtime)" \
+    || fail "$f missing hardened runtime"
+  echo "$INFO" | grep -q "^Timestamp=" \
+    || fail "$f missing secure timestamp"
+done < <(find "$APP_DIR" -type f -print0)
+
+# ---- Entitlement boundary: launcher none, bundled Pi exactly allow-jit ----
+codesign -d --entitlements :- --xml "$APP_DIR/Contents/MacOS/pi-launcher" > "$LAUNCHER_ENTITLEMENTS_XML" 2>/dev/null || true
+if [[ -s "$LAUNCHER_ENTITLEMENTS_XML" ]]; then
+  fail "launcher executable must have no entitlements"
+fi
+codesign -d --entitlements :- --xml "$APP_DIR/Contents/Resources/pi/pi" > "$PI_ENTITLEMENTS_XML" 2>/dev/null \
+  || fail "cannot read bundled Pi entitlements"
+[[ -s "$PI_ENTITLEMENTS_XML" ]] \
+  || fail "bundled Pi missing com.apple.security.cs.allow-jit entitlement"
+plutil -lint "$PI_ENTITLEMENTS_XML" >/dev/null \
+  || fail "bundled Pi entitlements plist is malformed"
+PI_JIT="$(/usr/libexec/PlistBuddy -c "Print :com.apple.security.cs.allow-jit" "$PI_ENTITLEMENTS_XML" 2>/dev/null || true)"
+[[ "$PI_JIT" == "true" ]] \
+  || fail "bundled Pi missing com.apple.security.cs.allow-jit entitlement"
+PI_ENTITLEMENT_KEYS="$(plutil -convert json -o - "$PI_ENTITLEMENTS_XML" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")"
+[[ "$PI_ENTITLEMENT_KEYS" == "1" ]] \
+  || fail "bundled Pi must have exactly one entitlement (allow-jit), found $PI_ENTITLEMENT_KEYS"
+
+# ---- Outer bundle identity and designated requirement ----
+APP_INFO="$(codesign -dvvv "$APP_DIR" 2>&1)"
+echo "$APP_INFO" | grep -q "^Identifier=$EXPECTED_BUNDLE_ID$" \
+  || fail "app signing identifier is not $EXPECTED_BUNDLE_ID"
+DR="$(codesign -d -r- "$APP_DIR" 2>&1)"
+echo "$DR" | grep -q "identifier \"$EXPECTED_BUNDLE_ID\"" \
+  || fail "designated requirement does not pin $EXPECTED_BUNDLE_ID"
+echo "$DR" | grep -q "anchor apple generic" \
+  || fail "designated requirement missing anchor apple generic"
+echo "$DR" | grep -Eq "certificate leaf\[subject\.OU\] = \"?$EXPECTED_TEAM_ID\"?$" \
+  || fail "designated requirement missing Team ID $EXPECTED_TEAM_ID"
+
+echo "verify-app: signatures OK (Developer ID, hardened runtime, secure timestamps)"
+
+if [[ "$MODE_GATEKEEPER" -eq 0 ]]; then
+  exit 0
+fi
+
+# ---- Notarization + Gatekeeper (final-artifact gate) ----
+xcrun stapler validate "$APP_DIR" >/dev/null \
+  || fail "no stapled notarization ticket"
+spctl --assess --type execute --verbose=4 "$APP_DIR" 2>&1 \
+  || fail "Gatekeeper assessment failed"
+SPCTL_OUT="$(spctl --assess --type execute --verbose=4 "$APP_DIR" 2>&1)"
+echo "$SPCTL_OUT" | grep -q "source=Notarized Developer ID" \
+  || fail "Gatekeeper source is not 'Notarized Developer ID'"
+
+echo "verify-app: Gatekeeper OK (notarized, stapled, accepted)"

--- a/src/pi-launcher.c
+++ b/src/pi-launcher.c
@@ -1,0 +1,237 @@
+/*
+ * pi-launcher - transparent fixed-target launcher for a bundled Pi CLI.
+ *
+ * Security and process contract (do not weaken):
+ *
+ *   - The only executable this program will ever run is the single Pi CLI
+ *     bundled inside its own app bundle at a fixed relative path. There is
+ *     no target option, no PATH lookup, no environment override, and no
+ *     shell. All command-line arguments are passed to Pi verbatim.
+ *
+ *   - The launcher stays alive as Pi's direct parent in the caller's
+ *     existing session: same controlling terminal, same process group,
+ *     same foreground job. It never allocates a PTY, never daemonizes,
+ *     never touches the terminal itself.
+ *
+ *   - Signals the terminal delivers to the foreground process group
+ *     (SIGINT, SIGQUIT, SIGTSTP, SIGWINCH, ...) reach Pi directly. The
+ *     launcher never re-delivers those, so Pi sees each one exactly once.
+ *     The launcher ignores SIGINT/SIGQUIT so it can outlive a Pi that
+ *     handles them, and it keeps default dispositions for the stop
+ *     signals so Pi's Ctrl-Z (which stops the whole process group) and
+ *     the shell's `fg` (which continues it) behave exactly as they do
+ *     for a directly invoked `pi`.
+ *
+ *   - Signals directed at the launcher process itself (SIGHUP, SIGTERM,
+ *     SIGUSR1, SIGUSR2) are forwarded to Pi once, so killing the
+ *     launcher cannot orphan a live Pi.
+ *
+ *   - The launcher reaps Pi and reproduces its result: Pi's exit code,
+ *     or death by the same signal that killed Pi.
+ */
+
+#include <errno.h>
+#include <libproc.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char **environ;
+
+/* Path of the bundled Pi CLI relative to this executable, which lives at
+ * <App>.app/Contents/MacOS/<launcher>. */
+static const char kPayloadRelPath[] = "../Resources/pi/pi";
+
+/* Signals directed at the launcher that are forwarded to Pi. Keyboard and
+ * job-control signals are deliberately absent: the terminal delivers those
+ * to the whole foreground process group, so Pi already receives them
+ * exactly once. */
+static const int kForwardedSignals[] = {SIGHUP, SIGTERM, SIGUSR1, SIGUSR2};
+
+/* Child process id, shared with the forwarding handler. 0 = not yet known. */
+static volatile sig_atomic_t g_child_pid = 0;
+
+static void forward_to_child(int sig) {
+  if (g_child_pid > 0) {
+    kill((pid_t)g_child_pid, sig);
+  }
+}
+
+/* Print a launcher-owned diagnostic and exit. These are the only bytes the
+ * launcher ever writes; everything else on stdio belongs to Pi. */
+static void die(int status, const char *what, const char *detail) {
+  if (detail != NULL) {
+    fprintf(stderr, "pi-launcher: %s: %s\n", what, detail);
+  } else {
+    fprintf(stderr, "pi-launcher: %s\n", what);
+  }
+  exit(status);
+}
+
+/* Resolve the absolute, symlink-free path of the bundled Pi CLI. */
+static void resolve_payload_path(char *out, size_t out_size) {
+  char self_path[PROC_PIDPATHINFO_MAXSIZE];
+  if (proc_pidpath(getpid(), self_path, sizeof(self_path)) <= 0) {
+    die(1, "cannot resolve own executable path", strerror(errno));
+  }
+
+  char resolved[PATH_MAX];
+  if (realpath(self_path, resolved) == NULL) {
+    die(1, "cannot canonicalize own executable path", strerror(errno));
+  }
+
+  char *slash = strrchr(resolved, '/');
+  if (slash == NULL || slash == resolved) {
+    die(1, "unexpected executable location", resolved);
+  }
+  *slash = '\0';
+
+  char joined[PATH_MAX];
+  if (snprintf(joined, sizeof(joined), "%s/%s", resolved, kPayloadRelPath) >=
+      (int)sizeof(joined)) {
+    die(1, "payload path too long", resolved);
+  }
+  if (realpath(joined, out) == NULL) {
+    if (errno == ENOENT) {
+      die(127, "bundled Pi is missing (reinstall the app)", joined);
+    }
+    die(1, "cannot canonicalize bundled Pi path", strerror(errno));
+  }
+  if (strlen(out) >= out_size) {
+    die(1, "payload path too long", joined);
+  }
+}
+
+static void check_payload(const char *path) {
+  struct stat st;
+  if (stat(path, &st) != 0) {
+    die(127, "bundled Pi is missing (reinstall the app)", path);
+  }
+  if (!S_ISREG(st.st_mode)) {
+    die(127, "bundled Pi is not a regular file", path);
+  }
+  if (access(path, X_OK) != 0) {
+    die(126, "bundled Pi is not executable", path);
+  }
+}
+
+/* Reset every catchable signal to its default disposition. The parent
+ * installs ignores/handlers for its own supervision; none of those may
+ * leak into Pi, because ignored dispositions survive exec. */
+static void reset_signal_dispositions(void) {
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = SIG_DFL;
+  sigemptyset(&sa.sa_mask);
+  for (int sig = 1; sig < NSIG; sig++) {
+    if (sig == SIGKILL || sig == SIGSTOP) {
+      continue;
+    }
+    sigaction(sig, &sa, NULL);
+  }
+}
+
+static void install_parent_dispositions(sigset_t *forwarded_mask) {
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = SA_RESTART;
+
+  /* The terminal already delivers these to Pi (same process group); the
+   * launcher must survive them so it can keep parenting a Pi that handles
+   * them, and must reproduce Pi's status if Pi dies from them. */
+  sa.sa_handler = SIG_IGN;
+  sigaction(SIGINT, &sa, NULL);
+  sigaction(SIGQUIT, &sa, NULL);
+
+  sa.sa_handler = forward_to_child;
+  sigemptyset(forwarded_mask);
+  for (size_t i = 0; i < sizeof(kForwardedSignals) / sizeof(kForwardedSignals[0]); i++) {
+    int sig = kForwardedSignals[i];
+    sigaction(sig, &sa, NULL);
+    sigaddset(forwarded_mask, sig);
+  }
+}
+
+int main(int argc, char *argv[]) {
+  char payload_path[PATH_MAX];
+  resolve_payload_path(payload_path, sizeof(payload_path));
+  check_payload(payload_path);
+
+  sigset_t forwarded_mask;
+  install_parent_dispositions(&forwarded_mask);
+
+  /* Block the forwarded signals around fork() so none can arrive before
+   * g_child_pid is set; the child unblocks them before exec. */
+  if (sigprocmask(SIG_BLOCK, &forwarded_mask, NULL) != 0) {
+    die(1, "cannot block signals", strerror(errno));
+  }
+
+  pid_t child = fork();
+  if (child < 0) {
+    die(1, "cannot fork", strerror(errno));
+  }
+
+  if (child == 0) {
+    /* Child: become Pi. Reset dispositions before unblocking so anything
+     * pending lands on a default disposition, never on the parent's
+     * forwarding handler. */
+    reset_signal_dispositions();
+    if (sigprocmask(SIG_UNBLOCK, &forwarded_mask, NULL) != 0) {
+      die(1, "cannot unblock signals", strerror(errno));
+    }
+
+    char **child_argv = calloc((size_t)argc + 1, sizeof(char *));
+    if (child_argv == NULL) {
+      die(1, "out of memory", NULL);
+    }
+    child_argv[0] = payload_path;
+    for (int i = 1; i < argc; i++) {
+      child_argv[i] = argv[i];
+    }
+    child_argv[argc] = NULL;
+
+    execve(payload_path, child_argv, environ);
+    die(127, "cannot execute bundled Pi", strerror(errno));
+  }
+
+  g_child_pid = child;
+  if (sigprocmask(SIG_UNBLOCK, &forwarded_mask, NULL) != 0) {
+    die(1, "cannot unblock signals", strerror(errno));
+  }
+
+  /* Parent: wait for Pi, nothing else. No WUNTRACED on purpose: stop and
+   * continue events are managed by the terminal and the shell at the
+   * process-group level (Pi stops the whole group on Ctrl-Z; the shell
+   * continues it on `fg`), so the launcher simply stops and resumes with
+   * its group like any other member. */
+  for (;;) {
+    int status = 0;
+    pid_t result = waitpid(child, &status, 0);
+    if (result < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      die(1, "cannot wait for bundled Pi", strerror(errno));
+    }
+    if (result != child) {
+      continue;
+    }
+    if (WIFEXITED(status)) {
+      return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+      int sig = WTERMSIG(status);
+      /* Die the way Pi died so the caller observes the identical wait
+       * status (e.g. exit code 130 for SIGINT). */
+      signal(sig, SIG_DFL);
+      kill(getpid(), sig);
+      _exit(128 + sig); /* Unreachable unless the signal is blocked. */
+    }
+  }
+}

--- a/tests/functional.py
+++ b/tests/functional.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+functional.py - pipe-based functional tests for pi-launcher.
+
+Drives the launcher from the TEST app bundle (Contents/Resources/pi/pi is
+the probe binary) and asserts the transparency contract: argv, env, cwd,
+stdio bytes, exit codes, signal deaths, parentage, and the fixed-target
+security boundary.
+
+Usage: functional.py <path-to-launcher-executable>
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+LAUNCHER = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else None
+if not LAUNCHER or not os.path.isfile(LAUNCHER):
+    print("usage: functional.py <launcher-executable>", file=sys.stderr)
+    sys.exit(2)
+
+FAILURES = []
+PASSES = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        PASSES.append(name)
+        print(f"PASS {name}")
+    else:
+        FAILURES.append(name)
+        print(f"FAIL {name} {detail}")
+
+
+def run_launcher(args, env=None, cwd=None, stdin_data=None):
+    """Run the launcher; return (proc, stdout, stderr)."""
+    full_env = dict(env) if env is not None else None
+    proc = subprocess.Popen(
+        [LAUNCHER] + args,
+        stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+        env=full_env,
+    )
+    out, err = proc.communicate(input=stdin_data)
+    return proc, out, err
+
+
+def parse_dump(out):
+    lines = out.decode("utf-8", errors="replace").splitlines()
+    result = {"argv": [], "env": {}}
+    i = 0
+    envname = None
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("PPID:"):
+            result["ppid"] = int(line[5:])
+        elif line.startswith("ARGC:"):
+            result["argc"] = int(line[5:])
+        elif line.startswith("ARGV"):
+            _, rest = line.split(":", 1)
+            length, hexdata = rest.split(":", 1)
+            result["argv"].append(bytes.fromhex(hexdata))
+        elif line.startswith("CWD:"):
+            result["cwd"] = line[4:]
+        elif line.startswith("ENVCOUNT:"):
+            result["envcount"] = int(line[9:])
+        elif line.startswith("ENVNAME:"):
+            _, _length, hexdata = line.split(":", 2)
+            envname = bytes.fromhex(hexdata)
+        elif line.startswith("ENVVALUE:"):
+            _, _length, hexdata = line.split(":", 2)
+            if envname is not None:
+                result["env"][envname] = bytes.fromhex(hexdata)
+                envname = None
+        i += 1
+    return result
+
+
+BASE_ENV = {
+    "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    "HOME": os.environ.get("HOME", "/tmp"),
+    "PROBE_MODE": "dump",
+}
+
+
+# 1. argv passthrough, byte-exact
+args = ["--target", "/bin/false", "hello world", "", "ünïcødé", "-p", "--model=x", "a\nb", "--"]
+proc, out, err = run_launcher(args, env=dict(BASE_ENV))
+dump = parse_dump(out)
+check(
+    "argv passthrough is byte-exact",
+    proc.returncode == 0
+    and dump["argv"][1:] == [a.encode() for a in args]
+    and dump["argc"] == len(args) + 1,
+    f"rc={proc.returncode} argv={dump.get('argv')}",
+)
+
+# 2. environment passthrough, byte-exact
+weird_env = dict(BASE_ENV)
+weird_env.update(
+    {
+        "EMPTY_VAR": "",
+        "UNICODE_VAR": "héllo ✓",
+        "NEWLINE_VAR": "line1\nline2",
+        "PROBE_MODE": "dump",
+    }
+)
+proc, out, err = run_launcher([], env=weird_env)
+dump = parse_dump(out)
+sent = {k.encode(): v.encode() for k, v in weird_env.items()}
+check(
+    "environment passthrough is byte-exact",
+    proc.returncode == 0 and dump["env"] == sent,
+    f"rc={proc.returncode} missing={set(sent) - set(dump.get('env', {}))}",
+)
+
+# 3. cwd passthrough
+with tempfile.TemporaryDirectory() as tmp:
+    subdir = os.path.join(tmp, "sub dir")
+    os.mkdir(subdir)
+    proc, out, err = run_launcher([], env=dict(BASE_ENV), cwd=subdir)
+    dump = parse_dump(out)
+    check(
+        "cwd passthrough",
+        proc.returncode == 0 and os.path.realpath(dump["cwd"]) == os.path.realpath(subdir),
+        f"rc={proc.returncode} cwd={dump.get('cwd')}",
+    )
+
+# 4. stdio byte transparency
+payload = bytes(range(256)) * 4 + os.urandom(1024 * 1024)
+env = dict(BASE_ENV, PROBE_MODE="cat", PROBE_EXIT="7")
+proc, out, err = run_launcher([], env=env, stdin_data=payload)
+check(
+    "stdin/stdout byte transparency",
+    proc.returncode == 7 and out == payload,
+    f"rc={proc.returncode} outlen={len(out)} want={len(payload)}",
+)
+check(
+    "stderr passthrough",
+    err == b"PROBE-STDERR-MARKER\n",
+    f"stderr={err[:80]!r}",
+)
+
+# 5. exit codes reproduce exactly
+ok = True
+for code in (0, 1, 42, 126, 127, 255):
+    proc, out, err = run_launcher([], env=dict(BASE_ENV, PROBE_EXIT=str(code)))
+    if proc.returncode != code:
+        ok = False
+        break
+check("exit codes reproduce", ok, f"last rc={proc.returncode} want={code}")
+
+# 6. signal deaths reproduce as the same signal
+ok = True
+detail = ""
+for signame in ("SIGTERM", "SIGKILL", "SIGABRT", "SIGINT", "SIGHUP"):
+    signum = getattr(signal, signame)
+    proc, out, err = run_launcher(
+        [], env=dict(BASE_ENV, PROBE_MODE="selfsig", PROBE_SIGNAL=signame)
+    )
+    if proc.returncode != -signum:
+        ok = False
+        detail = f"{signame}: launcher rc={proc.returncode} want={-signum}"
+        break
+check("signal deaths reproduce as same signal", ok, detail)
+
+# 7. launcher stays the direct parent
+env = dict(BASE_ENV)
+proc = subprocess.Popen(
+    [LAUNCHER], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+)
+out, err = proc.communicate()
+dump = parse_dump(out)
+check(
+    "probe is a direct child of the launcher",
+    proc.returncode == 0 and dump["ppid"] == proc.pid,
+    f"probe ppid={dump.get('ppid')} launcher pid={proc.pid}",
+)
+
+# 7b. a signal aimed at the launcher pid is forwarded to Pi exactly once,
+#     handled or fatal
+
+
+def read_until_ready(proc, timeout=10):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            break
+        if b"READY" in line:
+            return
+    raise RuntimeError("probe never became ready")
+
+
+# handled variant: probe counts deliveries and exits 55 on the first
+proc = subprocess.Popen(
+    [LAUNCHER],
+    env=dict(BASE_ENV, PROBE_MODE="sigwait"),
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+read_until_ready(proc)
+os.kill(proc.pid, signal.SIGTERM)
+out, err = proc.communicate(timeout=10)
+check(
+    "SIGTERM to launcher pid forwarded once, exit reproduced",
+    proc.returncode == 55 and out.count(b"EVT:SIGTERM") == 1,
+    f"rc={proc.returncode} out={out!r}",
+)
+
+# fatal variant: probe keeps the default disposition and dies by SIGTERM
+proc = subprocess.Popen(
+    [LAUNCHER],
+    env=dict(BASE_ENV, PROBE_MODE="sigwait", PROBE_TERM_DEFAULT="1"),
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+read_until_ready(proc)
+os.kill(proc.pid, signal.SIGTERM)
+out, err = proc.communicate(timeout=10)
+check(
+    "SIGTERM to launcher pid propagates as launcher death by SIGTERM",
+    proc.returncode == -signal.SIGTERM,
+    f"rc={proc.returncode}",
+)
+
+# 8. negative: env injection cannot redirect the target
+evil_dir = tempfile.mkdtemp()
+evil_pi = os.path.join(evil_dir, "pi")
+with open(evil_pi, "w") as f:
+    f.write("#!/bin/sh\necho EVIL-PATH-TARGET-RAN\nexit 99\n")
+os.chmod(evil_pi, 0o755)
+env = dict(BASE_ENV)
+env.update(
+    {
+        "PATH": evil_dir + ":" + env["PATH"],
+        "PI_LAUNCHER_TARGET": "/bin/false",
+        "PI_TARGET": "/bin/false",
+        "TARGET": "/bin/false",
+        "PI_LAUNCHER_COMMAND": "evil",
+    }
+)
+proc, out, err = run_launcher([], env=env)
+dump = parse_dump(out)
+check(
+    "no PATH or env target selection",
+    proc.returncode == 0
+    and b"EVIL-PATH-TARGET-RAN" not in out
+    and dump.get("argv", [b""])[0].endswith(b"/Contents/Resources/pi/pi"),
+    f"rc={proc.returncode} argv0={dump.get('argv', [None])[0]!r} out={out[:120]!r}",
+)
+
+# 9. negative: target-looking flags are passed through verbatim, not parsed
+proc, out, err = run_launcher(
+    ["--target", "/bin/false", "--command=evil", "--launcher-target=/bin/false"],
+    env=dict(BASE_ENV),
+)
+dump = parse_dump(out)
+check(
+    "no option parsing in the launcher",
+    proc.returncode == 0
+    and dump["argv"][1:] == [b"--target", b"/bin/false", b"--command=evil", b"--launcher-target=/bin/false"],
+    f"rc={proc.returncode} argv={dump.get('argv')}",
+)
+
+# 10. negative: launcher outside a bundle refuses to run anything
+rogue = os.path.join(evil_dir, "rogue-launcher")
+subprocess.run(["cp", LAUNCHER, rogue], check=True)
+proc = subprocess.Popen(
+    [rogue], env=dict(BASE_ENV), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+)
+out, err = proc.communicate()
+check(
+    "bare launcher binary has no fallback",
+    proc.returncode == 127 and b"pi-launcher:" in err and b"EVIL" not in out,
+    f"rc={proc.returncode} stderr={err[:160]!r}",
+)
+
+print()
+print(f"functional: {len(PASSES)} passed, {len(FAILURES)} failed")
+sys.exit(1 if FAILURES else 0)

--- a/tests/probe.c
+++ b/tests/probe.c
@@ -1,0 +1,362 @@
+/*
+ * probe.c - test double that stands in for the bundled Pi payload.
+ *
+ * The launcher under test never knows the difference: it resolves and
+ * execs Contents/Resources/pi/pi, which in the test bundle is this
+ * binary. The probe exposes what the launcher must preserve: argv,
+ * environment, cwd, stdio bytes, terminal state, signals, and exit/signal
+ * termination. Modes are selected with PROBE_MODE so the same binary
+ * covers every test.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+static struct termios g_saved_termios;
+static bool g_termios_saved = false;
+static volatile sig_atomic_t g_sigint_count = 0;
+static volatile sig_atomic_t g_sigcont_count = 0;
+
+static void die(const char *what) {
+  fprintf(stderr, "probe: %s: %s\n", what, strerror(errno));
+  _exit(111);
+}
+
+static void print_hex_bytes(const char *label, const char *data, size_t len) {
+  printf("%s%zu:", label, len);
+  for (size_t i = 0; i < len; i++) {
+    printf("%02x", (unsigned char)data[i]);
+  }
+  printf("\n");
+}
+
+static int env_cmp(const void *a, const void *b) {
+  return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+extern char **environ;
+
+/* dump: report argv, environment, cwd, and parent, then exit. */
+static int mode_dump(int argc, char *argv[]) {
+  printf("PPID:%d\n", (int)getppid());
+  printf("ARGC:%d\n", argc);
+  for (int i = 0; i < argc; i++) {
+    char label[32];
+    snprintf(label, sizeof(label), "ARGV%d:", i);
+    print_hex_bytes(label, argv[i], strlen(argv[i]));
+  }
+  char cwd[4096];
+  if (getcwd(cwd, sizeof(cwd)) == NULL) {
+    die("getcwd");
+  }
+  printf("CWD:%s\n", cwd);
+
+  size_t count = 0;
+  for (char **e = environ; *e != NULL; e++) {
+    count++;
+  }
+  char **sorted = calloc(count, sizeof(char *));
+  if (sorted == NULL) {
+    die("calloc");
+  }
+  for (size_t i = 0; i < count; i++) {
+    sorted[i] = environ[i];
+  }
+  qsort(sorted, count, sizeof(char *), env_cmp);
+  printf("ENVCOUNT:%zu\n", count);
+  for (size_t i = 0; i < count; i++) {
+    const char *eq = strchr(sorted[i], '=');
+    if (eq == NULL) {
+      print_hex_bytes("ENVNAME:", sorted[i], strlen(sorted[i]));
+      printf("ENVVALUE:0:\n");
+    } else {
+      print_hex_bytes("ENVNAME:", sorted[i], (size_t)(eq - sorted[i]));
+      print_hex_bytes("ENVVALUE:", eq + 1, strlen(eq + 1));
+    }
+  }
+  fflush(stdout);
+  const char *code = getenv("PROBE_EXIT");
+  return code != NULL ? atoi(code) : 0;
+}
+
+/* cat: copy stdin to stdout byte-exact, then mark stderr and exit. */
+static int mode_cat(void) {
+  char buf[65536];
+  for (;;) {
+    ssize_t n = read(STDIN_FILENO, buf, sizeof(buf));
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      die("read");
+    }
+    if (n == 0) {
+      break;
+    }
+    ssize_t off = 0;
+    while (off < n) {
+      ssize_t w = write(STDOUT_FILENO, buf + off, (size_t)(n - off));
+      if (w < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        die("write");
+      }
+      off += w;
+    }
+  }
+  const char *marker = "PROBE-STDERR-MARKER\n";
+  (void)write(STDERR_FILENO, marker, strlen(marker));
+  const char *code = getenv("PROBE_EXIT");
+  return code != NULL ? atoi(code) : 0;
+}
+
+/* selfsig: die by the signal named in PROBE_SIGNAL. */
+static int mode_selfsig(void) {
+  const char *name = getenv("PROBE_SIGNAL");
+  if (name == NULL) {
+    die("PROBE_SIGNAL unset");
+  }
+  int sig = 0;
+  if (strcmp(name, "SIGTERM") == 0) sig = SIGTERM;
+  else if (strcmp(name, "SIGKILL") == 0) sig = SIGKILL;
+  else if (strcmp(name, "SIGABRT") == 0) sig = SIGABRT;
+  else if (strcmp(name, "SIGINT") == 0) sig = SIGINT;
+  else if (strcmp(name, "SIGHUP") == 0) sig = SIGHUP;
+  else die("unknown PROBE_SIGNAL");
+  kill(getpid(), sig);
+  _exit(112); /* Unreachable for fatal signals. */
+}
+
+static void restore_termios(void) {
+  if (g_termios_saved) {
+    tcsetattr(STDIN_FILENO, TCSANOW, &g_saved_termios);
+    g_termios_saved = false;
+  }
+}
+
+static void set_termios(bool raw) {
+  if (tcgetattr(STDIN_FILENO, &g_saved_termios) != 0) {
+    die("tcgetattr");
+  }
+  g_termios_saved = true;
+  struct termios t = g_saved_termios;
+  if (raw) {
+    cfmakeraw(&t);
+  } else {
+    /* cbreak: byte-at-a-time reads, no echo, but ISIG stays on so the
+     * line discipline still generates SIGINT/SIGTSTP from ^C/^Z. */
+    t.c_lflag &= (tcflag_t)~(ICANON | ECHO);
+    t.c_cc[VMIN] = 1;
+    t.c_cc[VTIME] = 0;
+  }
+  if (tcsetattr(STDIN_FILENO, TCSANOW, &t) != 0) {
+    die("tcsetattr");
+  }
+}
+
+static void write_all_stdout(const char *data, size_t len) {
+  size_t off = 0;
+  while (off < len) {
+    ssize_t w = write(STDOUT_FILENO, data + off, len - off);
+    if (w < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      _exit(113);
+    }
+    off += (size_t)w;
+  }
+}
+
+static void on_sigint(int sig) {
+  (void)sig;
+  g_sigint_count++;
+  char buf[32];
+  int n = snprintf(buf, sizeof(buf), "EVT:SIGINT:%d\n", (int)g_sigint_count);
+  write_all_stdout(buf, (size_t)n);
+}
+
+static void on_sigcont(int sig) {
+  (void)sig;
+  g_sigcont_count++;
+  char buf[32];
+  int n = snprintf(buf, sizeof(buf), "EVT:SIGCONT:%d\n", (int)g_sigcont_count);
+  write_all_stdout(buf, (size_t)n);
+}
+
+static void on_sigwinch(int sig) {
+  (void)sig;
+  struct winsize ws;
+  char buf[64];
+  if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) == 0) {
+    int n = snprintf(buf, sizeof(buf), "EVT:SIGWINCH:%ux%u\n", ws.ws_row, ws.ws_col);
+    write_all_stdout(buf, (size_t)n);
+  }
+}
+
+/*
+ * tty: report terminal/session facts, then play a scripted byte protocol
+ * on stdin until 'q':
+ *   'z' -> print SUSPEND and stop the whole process group (Pi's Ctrl-Z)
+ *   'q' -> restore termios, print BYE, exit PROBE_EXIT (default 42)
+ *   any other byte -> ignored (events come from signal handlers)
+ * PROBE_TERMIOS=raw uses full raw mode (default cbreak).
+ * PROBE_NO_SIGINT_HANDLER=1 leaves SIGINT at its default disposition.
+ */
+static int mode_tty(void) {
+  printf("PPID:%d\n", (int)getppid());
+  printf("SID:%d\n", (int)getsid(0));
+  printf("PGRP:%d\n", (int)getpgrp());
+  printf("ISATTY:%d%d%d\n", isatty(0) ? 1 : 0, isatty(1) ? 1 : 0, isatty(2) ? 1 : 0);
+  pid_t fg = tcgetpgrp(STDIN_FILENO);
+  printf("TCGETPGRP:%d\n", (int)fg);
+  printf("FG:%d\n", fg == getpgrp() ? 1 : 0);
+  struct winsize ws;
+  if (ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) != 0) {
+    die("TIOCGWINSZ");
+  }
+  printf("WINSZ:%ux%u\n", ws.ws_row, ws.ws_col);
+
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sigemptyset(&sa.sa_mask);
+  if (getenv("PROBE_NO_SIGINT_HANDLER") == NULL) {
+    sa.sa_handler = on_sigint;
+    sigaction(SIGINT, &sa, NULL);
+  }
+  sa.sa_handler = on_sigcont;
+  sigaction(SIGCONT, &sa, NULL);
+  sa.sa_handler = on_sigwinch;
+  sigaction(SIGWINCH, &sa, NULL);
+
+  bool raw = getenv("PROBE_TERMIOS") != NULL && strcmp(getenv("PROBE_TERMIOS"), "raw") == 0;
+  set_termios(raw);
+  printf("READY\n");
+  fflush(stdout);
+
+  for (;;) {
+    unsigned char c;
+    ssize_t n = read(STDIN_FILENO, &c, 1);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      restore_termios();
+      die("read");
+    }
+    if (n == 0) {
+      restore_termios();
+      die("unexpected EOF");
+    }
+    if (c == 'q') {
+      restore_termios();
+      printf("BYE\n");
+      fflush(stdout);
+      const char *code = getenv("PROBE_EXIT");
+      return code != NULL ? atoi(code) : 42;
+    }
+    if (c == 'z') {
+      printf("SUSPEND\n");
+      fflush(stdout);
+      /* Exactly what Pi does on Ctrl-Z: stop the whole process group. */
+      kill(0, SIGTSTP);
+    }
+  }
+}
+
+static volatile sig_atomic_t g_sigterm_count = 0;
+
+static void on_sigterm_count(int sig) {
+  (void)sig;
+  g_sigterm_count++;
+  char buf[32];
+  int n = snprintf(buf, sizeof(buf), "EVT:SIGTERM:%d\n", (int)g_sigterm_count);
+  write_all_stdout(buf, (size_t)n);
+}
+
+/* sigwait: count SIGTERM deliveries and exit 55 on the first one (or die
+ * by SIGTERM's default disposition when PROBE_TERM_DEFAULT=1). Proves a
+ * signal aimed at the launcher pid is forwarded to Pi exactly once. */
+static int mode_sigwait(void) {
+  printf("READY\n");
+  fflush(stdout);
+  if (getenv("PROBE_TERM_DEFAULT") == NULL) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = on_sigterm_count;
+    sigaction(SIGTERM, &sa, NULL);
+  }
+  for (;;) {
+    if (g_sigterm_count > 0) {
+      return 55;
+    }
+    pause();
+  }
+}
+
+/* rawecho: full raw mode, echo exactly PROBE_ECHO_COUNT bytes, exit 0. */
+static int mode_rawecho(void) {
+  const char *count_env = getenv("PROBE_ECHO_COUNT");
+  long remaining = count_env != NULL ? atol(count_env) : 512;
+  set_termios(true);
+  printf("READY\n");
+  fflush(stdout);
+  while (remaining > 0) {
+    unsigned char buf[4096];
+    long chunk = remaining < (long)sizeof(buf) ? remaining : (long)sizeof(buf);
+    ssize_t n = read(STDIN_FILENO, buf, (size_t)chunk);
+    if (n < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      restore_termios();
+      die("read");
+    }
+    if (n == 0) {
+      restore_termios();
+      die("unexpected EOF");
+    }
+    write_all_stdout((const char *)buf, (size_t)n);
+    remaining -= n;
+  }
+  restore_termios();
+  printf("DONE\n");
+  fflush(stdout);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  const char *mode = getenv("PROBE_MODE");
+  if (mode == NULL) {
+    mode = "dump";
+  }
+  int rc;
+  if (strcmp(mode, "dump") == 0) {
+    rc = mode_dump(argc, argv);
+  } else if (strcmp(mode, "cat") == 0) {
+    rc = mode_cat();
+  } else if (strcmp(mode, "selfsig") == 0) {
+    rc = mode_selfsig();
+  } else if (strcmp(mode, "tty") == 0) {
+    rc = mode_tty();
+  } else if (strcmp(mode, "sigwait") == 0) {
+    rc = mode_sigwait();
+  } else if (strcmp(mode, "rawecho") == 0) {
+    rc = mode_rawecho();
+  } else {
+    fprintf(stderr, "probe: unknown PROBE_MODE %s\n", mode);
+    rc = 111;
+  }
+  return rc;
+}

--- a/tests/pty_tests.py
+++ b/tests/pty_tests.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""
+pty_tests.py - real pseudo-terminal tests for pi-launcher.
+
+Each test creates a fresh PTY and a "shell" session leader that starts the
+launcher as a foreground job (own process group, terminal handed over),
+exactly like an interactive shell. The harness then drives the master side
+and asserts the terminal semantics the launcher must preserve: controlling
+TTY, foreground process group, winsize/SIGWINCH, Ctrl-C, Ctrl-Z/fg job
+control, Pi-style group suspend, and raw byte transparency.
+
+Usage: pty_tests.py <path-to-launcher-executable>
+"""
+
+import errno
+import fcntl
+import json
+import os
+import select
+import signal
+import struct
+import sys
+import termios
+import time
+
+LAUNCHER = sys.argv[1] if len(sys.argv) > 1 else None
+if not LAUNCHER or not os.path.isfile(LAUNCHER):
+    print("usage: pty_tests.py <launcher-executable>", file=sys.stderr)
+    sys.exit(2)
+
+FAILURES = []
+PASSES = []
+TIMEOUT = 20.0
+
+
+def check(name, condition, detail=""):
+    if condition:
+        PASSES.append(name)
+        print(f"PASS {name}")
+    else:
+        FAILURES.append(name)
+        print(f"FAIL {name} {detail}")
+
+
+def shell_child(slave, result_w, cmd_r, launcher_argv, launcher_env):
+    """Session leader acting as the interactive shell."""
+    os.setsid()
+    fcntl.ioctl(slave, termios.TIOCSCTTY, 0)
+    os.dup2(slave, 0)
+    os.dup2(slave, 1)
+    os.dup2(slave, 2)
+    if slave > 2:
+        os.close(slave)
+
+    # tcsetpgrp from a background process group raises SIGTTOU; block it
+    # like every real shell does.
+    signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGTTOU})
+
+    def report(event):
+        os.write(result_w, (json.dumps(event) + "\n").encode())
+
+    lpid = os.fork()
+    if lpid == 0:
+        try:
+            os.setpgid(0, 0)
+            os.execve(launcher_argv[0], launcher_argv, launcher_env)
+        except BaseException:
+            os._exit(127)
+    os.setpgid(lpid, lpid)
+    os.tcsetpgrp(0, lpid)
+    report({"event": "spawned", "pid": lpid, "sid": os.getsid(0)})
+
+    for _ in range(64):
+        _, status = os.waitpid(lpid, os.WUNTRACED)
+        if os.WIFSTOPPED(status):
+            report({"event": "stopped", "sig": os.WSTOPSIG(status)})
+            # Wait for the harness to order a foreground resume.
+            cmd = b""
+            while not cmd.startswith(b"fg"):
+                chunk = os.read(cmd_r, 2)
+                if not chunk:
+                    os._exit(3)
+                cmd += chunk
+            os.killpg(lpid, signal.SIGCONT)
+            continue
+        if os.WIFEXITED(status):
+            report({"event": "exit", "code": os.WEXITSTATUS(status)})
+            os._exit(0)
+        if os.WIFSIGNALED(status):
+            report({"event": "signaled", "sig": os.WTERMSIG(status)})
+            os._exit(0)
+    os._exit(4)
+
+
+class PtySession:
+    def __init__(self, env, rows=43, cols=132, args=None):
+        self.env = env
+        self.args = args or []
+        self.master, slave = os.openpty()
+        fcntl.ioctl(
+            slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0)
+        )
+        self.result_r, result_w = os.pipe()
+        cmd_r, self.cmd_w = os.pipe()
+        self.shell_pid = os.fork()
+        if self.shell_pid == 0:
+            os.close(self.master)
+            os.close(self.result_r)
+            os.close(self.cmd_w)
+            try:
+                shell_child(
+                    slave,
+                    result_w,
+                    cmd_r,
+                    [LAUNCHER] + self.args,
+                    self.env,
+                )
+            finally:
+                os._exit(5)
+        os.close(slave)
+        os.close(result_w)
+        os.close(cmd_r)
+        self.output = b""
+        self.events = []
+        self._result_buf = b""
+        self.deadline = time.monotonic() + TIMEOUT
+
+    def _read_available(self):
+        """Pull whatever is ready from master + result pipe."""
+        fds = [self.master, self.result_r]
+        while True:
+            remaining = self.deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("pty session timed out")
+            r, _, _ = select.select(fds, [], [], min(remaining, 0.25))
+            if not r:
+                return
+            for fd in r:
+                try:
+                    data = os.read(fd, 65536)
+                except OSError as exc:
+                    if exc.errno == errno.EIO and fd == self.master:
+                        data = b""
+                    else:
+                        raise
+                if not data:
+                    if fd == self.master:
+                        self.master = -1
+                        fds.remove(fd)
+                    else:
+                        self.result_r = -1
+                        fds.remove(fd)
+                    continue
+                if fd == self.master:
+                    self.output += data
+                else:
+                    self._result_buf += data
+                    while b"\n" in self._result_buf:
+                        line, self._result_buf = self._result_buf.split(b"\n", 1)
+                        self.events.append(json.loads(line.decode()))
+
+    def wait_event(self, kind):
+        """Wait for a shell event of the given kind."""
+        while True:
+            for event in self.events:
+                if event["event"] == kind:
+                    return event
+            self._read_available()
+            if self.result_r == -1:
+                raise RuntimeError(f"result pipe closed before event {kind}")
+
+    def wait_output(self, marker, since=0):
+        """Wait until marker (bytes) appears in master output at >= since."""
+        while True:
+            idx = self.output.find(marker, since)
+            if idx >= 0:
+                return idx + len(marker)
+            self._read_available()
+            if self.master == -1:
+                raise RuntimeError(f"master closed before {marker!r}; got {self.output!r}")
+
+    def output_quiet(self, quiet_seconds=0.4):
+        """Wait for output to settle; return True if no new bytes arrived."""
+        end = time.monotonic() + quiet_seconds
+        before = len(self.output)
+        while time.monotonic() < end:
+            try:
+                self._read_available()
+            except TimeoutError:
+                break
+        return len(self.output) == before
+
+    def write(self, data):
+        os.write(self.master, data)
+
+    def foreground(self):
+        os.write(self.cmd_w, b"fg")
+
+    def resize(self, rows, cols):
+        fcntl.ioctl(
+            self.master, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0)
+        )
+
+    def finish(self):
+        """Final launcher status event; also reaps the shell child."""
+        event = None
+        try:
+            while True:
+                for e in self.events:
+                    if e["event"] in ("exit", "signaled"):
+                        event = e
+                        break
+                if event:
+                    break
+                if self.result_r == -1:
+                    break
+                self._read_available()
+        except (TimeoutError, RuntimeError):
+            pass
+        for fd in (self.master, self.result_r, self.cmd_w):
+            try:
+                if fd != -1:
+                    os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.waitpid(self.shell_pid, 0)
+        except ChildProcessError:
+            pass
+        return event
+
+    def abort(self):
+        try:
+            os.kill(self.shell_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        self.finish()
+
+
+def base_env(mode):
+    return {
+        "PATH": "/usr/bin:/bin",
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "PROBE_MODE": mode,
+    }
+
+
+def normalized(session, since=0):
+    return session.output[since:].replace(b"\r\n", b"\n")
+
+
+# --- Test 1: controlling TTY, foreground pgrp, session, winsize ----------
+session = PtySession(base_env("tty"), rows=43, cols=132)
+try:
+    spawned = session.wait_event("spawned")
+    session.wait_output(b"READY")
+    text = normalized(session).decode()
+    facts = dict(
+        line.split(":", 1) for line in text.splitlines() if ":" in line
+    )
+    session.write(b"q")
+    final = session.finish()
+    check(
+        "tty: probe has controlling tty on all stdio fds",
+        facts.get("ISATTY") == "111",
+        str(facts),
+    )
+    check(
+        "tty: probe process group is the terminal foreground group",
+        facts.get("FG") == "1" and facts.get("TCGETPGRP") == facts.get("PGRP"),
+        str(facts),
+    )
+    check(
+        "tty: terminal size inherited",
+        facts.get("WINSZ") == "43x132",
+        str(facts),
+    )
+    check(
+        "tty: probe is in the caller's session and is the launcher's child",
+        facts.get("SID") == str(spawned["sid"])
+        and facts.get("PPID") == str(spawned["pid"]),
+        f"facts={facts} spawned={spawned}",
+    )
+    check(
+        "tty: exit status through PTY session",
+        final and final["event"] == "exit" and final["code"] == 42,
+        str(final),
+    )
+except Exception as exc:
+    session.abort()
+    check("tty session facts", False, repr(exc))
+
+
+# --- Test 2: resize delivers SIGWINCH with the new size ------------------
+session = PtySession(base_env("tty"))
+try:
+    session.wait_event("spawned")
+    session.wait_output(b"READY")
+    mark = len(session.output)
+    session.resize(40, 100)
+    session.wait_output(b"EVT:SIGWINCH:40x100", since=mark)
+    quiet = session.output_quiet()
+    text = normalized(session, since=mark)
+    occurrences = text.count(b"EVT:SIGWINCH")
+    session.write(b"q")
+    final = session.finish()
+    check(
+        "resize: SIGWINCH delivered once with new size",
+        occurrences == 1 and quiet,
+        f"occurrences={occurrences} out={text!r}",
+    )
+    check("resize: session still healthy", final and final["event"] == "exit" and final["code"] == 42, str(final))
+except Exception as exc:
+    session.abort()
+    check("resize SIGWINCH", False, repr(exc))
+
+
+# --- Test 3: Ctrl-C reaches Pi exactly once, launcher survives -----------
+session = PtySession(base_env("tty"))
+try:
+    session.wait_event("spawned")
+    session.wait_output(b"READY")
+    mark = len(session.output)
+    session.write(b"\x03")  # ^C -> SIGINT to the foreground process group
+    session.wait_output(b"EVT:SIGINT:1", since=mark)
+    quiet = session.output_quiet()
+    text = normalized(session, since=mark)
+    occurrences = text.count(b"EVT:SIGINT")
+    session.write(b"q")
+    final = session.finish()
+    check(
+        "ctrl-c: SIGINT delivered exactly once",
+        occurrences == 1 and quiet,
+        f"occurrences={occurrences} out={text!r}",
+    )
+    check(
+        "ctrl-c: launcher survived a handled SIGINT and reproduced exit 42",
+        final and final["event"] == "exit" and final["code"] == 42,
+        str(final),
+    )
+except Exception as exc:
+    session.abort()
+    check("ctrl-c handled", False, repr(exc))
+
+
+# --- Test 4: Ctrl-C with default disposition kills launcher by SIGINT ----
+session = PtySession(dict(base_env("tty"), PROBE_NO_SIGINT_HANDLER="1"))
+try:
+    session.wait_event("spawned")
+    session.wait_output(b"READY")
+    session.write(b"\x03")
+    final = session.finish()
+    check(
+        "ctrl-c: fatal SIGINT reproduces as launcher death by SIGINT",
+        final and final["event"] == "signaled" and final["sig"] == signal.SIGINT,
+        str(final),
+    )
+except Exception as exc:
+    session.abort()
+    check("ctrl-c fatal", False, repr(exc))
+
+
+# --- Test 5: keyboard Ctrl-Z stop and fg resume --------------------------
+session = PtySession(base_env("tty"))
+try:
+    session.wait_event("spawned")
+    session.wait_output(b"READY")
+    mark = len(session.output)
+    session.write(b"\x1a")  # ^Z -> SIGTSTP from the line discipline
+    stopped = session.wait_event("stopped")
+    check(
+        "ctrl-z: launcher job stopped with SIGTSTP",
+        stopped["sig"] == signal.SIGTSTP,
+        str(stopped),
+    )
+    session.foreground()
+    session.wait_output(b"EVT:SIGCONT:1", since=mark)
+    quiet = session.output_quiet()
+    text = normalized(session, since=mark)
+    occurrences = text.count(b"EVT:SIGCONT")
+    session.write(b"q")
+    final = session.finish()
+    check(
+        "ctrl-z: fg resumed the job exactly once",
+        occurrences == 1 and quiet,
+        f"occurrences={occurrences} out={text!r}",
+    )
+    check(
+        "ctrl-z: exit status after resume",
+        final and final["event"] == "exit" and final["code"] == 42,
+        str(final),
+    )
+except Exception as exc:
+    session.abort()
+    check("ctrl-z keyboard job control", False, repr(exc))
+
+
+# --- Test 6: Pi-style suspend (kill(0, SIGTSTP)) and fg resume -----------
+session = PtySession(base_env("tty"))
+try:
+    session.wait_event("spawned")
+    session.wait_output(b"READY")
+    mark = len(session.output)
+    session.write(b"z")  # probe stops its whole process group, like Pi's Ctrl-Z
+    session.wait_output(b"SUSPEND", since=mark)
+    stopped = session.wait_event("stopped")
+    check(
+        "pi-suspend: launcher job stopped with SIGTSTP",
+        stopped["sig"] == signal.SIGTSTP,
+        str(stopped),
+    )
+    session.foreground()
+    session.wait_output(b"EVT:SIGCONT:1", since=mark)
+    quiet = session.output_quiet()
+    occurrences = normalized(session, since=mark).count(b"EVT:SIGCONT")
+    session.write(b"q")
+    final = session.finish()
+    check(
+        "pi-suspend: fg resumed the job exactly once",
+        occurrences == 1 and quiet,
+        f"occurrences={occurrences}",
+    )
+    check(
+        "pi-suspend: exit status after resume",
+        final and final["event"] == "exit" and final["code"] == 42,
+        str(final),
+    )
+except Exception as exc:
+    session.abort()
+    check("pi-style group suspend", False, repr(exc))
+
+
+# --- Test 7: raw-mode byte transparency through the PTY ------------------
+session = PtySession(dict(base_env("rawecho"), PROBE_ECHO_COUNT="512"))
+try:
+    session.wait_event("spawned")
+    session.wait_output(b"READY")
+    # Drain READY (and anything else) so the echo stream starts clean.
+    try:
+        while True:
+            r, _, _ = select.select([session.master], [], [], 0.2)
+            if not r:
+                break
+            os.read(session.master, 65536)
+    except OSError:
+        pass
+    blob = bytes(range(256)) * 2
+    echoed = b""
+    sent = 0
+    deadline = time.monotonic() + TIMEOUT
+    while sent < len(blob) or len(echoed) < len(blob):
+        if time.monotonic() > deadline:
+            raise TimeoutError("rawecho stalled")
+        r, w, _ = select.select([session.master], [session.master], [], 0.25)
+        if w and sent < len(blob):
+            sent += os.write(session.master, blob[sent : sent + 4096])
+        if r:
+            echoed += os.read(session.master, 65536)
+    # The probe's trailing DONE line may share the last read; only the
+    # first len(blob) echo bytes are the transparency proof.
+    final = session.finish()
+    check(
+        "raw PTY byte transparency (all 256 byte values)",
+        echoed[: len(blob)] == blob,
+        f"echoed {len(echoed)} bytes, match={echoed[: len(blob)] == blob}",
+    )
+    check(
+        "rawecho: clean exit",
+        final and final["event"] == "exit" and final["code"] == 0,
+        str(final),
+    )
+except Exception as exc:
+    session.abort()
+    check("raw PTY byte transparency", False, repr(exc))
+
+
+print()
+print(f"pty: {len(PASSES)} passed, {len(FAILURES)} failed")
+sys.exit(1 if FAILURES else 0)


### PR DESCRIPTION
## What

First public release of `pi-launcher`: a minimal `Pi Launcher.app` (stable bundle id `com.kunchenguid.pi-launcher`, LSUIElement) whose command-line executable spawns the one bundled official Pi CLI and stays alive as Pi's direct parent in the caller's existing terminal. It gives Pi's process tree a stable signed app identity without changing anything about how Pi behaves in the terminal.

Not a GUI, terminal emulator, PTY proxy, session manager, or command wrapper. No target option, no PATH resolution, no shell - the only executable it can run is `Contents/Resources/pi/pi` inside its own bundle.

## Why (baseline evidence, reproduced before implementation)

The official Pi standalone macOS binary has no stable signing identity. Reproduced 2026-07-24 on macOS arm64 with non-secret evidence only:

```
$ shasum -a 256 pi-darwin-arm64.tar.gz
6205debd0071ff56d765e0ee941f087f9a18d1f6c2f7dea17bdc8f97ff3cf9c1   (matches upstream SHA256SUMS)

$ codesign -dvvv pi
Identifier=a.out
CodeDirectory v=20400 size=590750 flags=0x20002(adhoc,linker-signed)
TeamIdentifier=not set
Signature=adhoc

$ codesign -d -r- pi
designated => cdhash H"0faa740b1e7c6d708e252b370db108eaf1dd7a83"   # per-build cdhash, changes every build

$ spctl --assess --type execute pi
pi: invalid signature (code or signature have been modified)          # Gatekeeper: rejected
```

This matches the scout report (`dfp-pi-public-signed-launcher-scout-r1`) exactly. The bundled `.node` natives are ad-hoc too. A per-build cdhash gives tools that bind trust to code-signed app identity (Automic Vault in Kun's setup) nothing stable to attach policy to.

## Design

- **Fixed bundled target**: official `pi-darwin-arm64.tar.gz` v0.82.0, pinned by version, URL, SHA-256 (and upstream license SHA-256) in `packaging/pi-release.json`; verified against the pin AND upstream `SHA256SUMS` on every fetch. Upstream MIT license ships in the bundle.
- **Same process group, fork+exec**: the launcher stays in Pi's process group (the shell's foreground job). Verified against upstream source: Pi's Ctrl-Z is `process.kill(0, "SIGTSTP")`, a group-wide stop, so stop/`fg` work through the group with zero launcher machinery. Keyboard signals reach Pi via the group exactly once; the launcher only forwards signals aimed at its own pid (HUP/TERM/USR1/USR2), each exactly once, and reproduces Pi's exit code or signal death.
- **Minimal native implementation**: one C file (~240 lines), libSystem only. No framework, updater, telemetry, network, config layer.
- **Release pipeline** (modeled on HiBit, same canonical secret names): tag-based; signs nested code inside-out with Developer ID `9T2J7MNUP9` (hardened runtime, secure timestamps, `allow-jit` only on the bundled Pi binary, zero entitlements on the launcher), notarizes, staples, and stops on any failed gate. It verifies the publication-ready zip AND the downloaded published artifact, not just intermediates.
- **Homebrew-ready**: versioned `Pi-Launcher-<version>.zip` + `.sha256` sidecar; exact cask shape at `homebrew/pi-launcher.rb` for the later tap task (not modified here).

## Tests (all run locally on this branch; CI runs the same without signing secrets)

- **Functional (13)**: argv/env/cwd byte-exact, stdio byte transparency (incl. 1MB random + all byte values), exit codes 0/1/42/126/127/255, signal deaths (TERM/KILL/ABRT/INT/HUP) reproduced as the same signal, direct-parent proof, targeted-SIGTERM forwarding (handled and fatal variants), and negative tests: no PATH/env target selection, no option parsing, no fallback when the binary runs outside a bundle.
- **PTY (18)**: real pseudo-terminal harness with a shell-like session leader: controlling TTY on all fds, foreground process group, winsize inheritance, resize -> SIGWINCH once, Ctrl-C delivered exactly once (handled -> launcher survives and reproduces exit 42; default -> launcher dies by SIGINT), keyboard Ctrl-Z and Pi-style group suspend -> shell-level stop -> `fg` resume exactly once, raw-mode byte transparency for all 256 byte values.
- **Bundled-Pi smoke**: the real app runs the real Pi through the launcher: `--version` matches the pin, theme loading works, and an interactive TUI session renders and exits 0 via `/quit` (verified manually in a PTY).
- **Contract CI**: `scripts/check-release-contract.py` validates the release gates/order, canonical secret names only, pinned Team ID/bundle ID, PR test wiring, cask contract, upstream checksum liveness, and absence of key material.

## Scope boundary (per task)

No tag or release cut, no tap changes, no install, no change to the live `pi` command, no Automic invocation, no signing secrets read or provisioned. Release requires the five canonical secrets on this repo (`MAC_DEVELOPER_ID_CERT_P12`, `MAC_DEVELOPER_ID_CERT_PASSWORD`, `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_API_KEY`) - provisioning is a captain task documented in `RELEASE.md`.
