### PR TITLE
Add original macOS app icon and clarify independent status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Build the unsigned development app
         run: scripts/build-app.sh
 
+      - name: Verify icon and metadata contract
+        run: make test-icon
+
       - name: Run functional tests
         run: make test-functional
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ pi-launcher: a minimal signed macOS app whose executable spawns the one bundled 
 - `src/pi-launcher.c` - the entire launcher. Header comment documents the signal contract.
 - `tests/probe.c` + `tests/functional.py` + `tests/pty_tests.py` - probe-payload test double driven through real PTYs; `make test` runs everything including the bundled-Pi smoke.
 - `scripts/` - fetch/build/sign/verify pipeline; `check-release-contract.py` is the secret-free CI gate for workflow/packaging changes.
+- `packaging/icon/AppIcon.svg` - source for the original app icon; `scripts/build-icon.sh` renders the iconset and icns under ignored `build/`. Do not substitute Pi brand assets without explicit third-party app-branding permission.
 - `.github/workflows/` - `ci.yml` (PR tests, no secrets), `release.yml` (tag-based signed/notarized release; canonical secret names documented in `RELEASE.md`).
 - `homebrew/pi-launcher.rb` - cask contract for the separate tap task; never publish from this repo.
 - Team ID `9T2J7MNUP9`, bundle id `com.kunchenguid.pi-launcher`, app `Pi Launcher.app`, asset `Pi-Launcher-<version>.zip`.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LAUNCHER_EXE := $(APP)/Contents/MacOS/pi-launcher
 TEST_LAUNCHER_EXE := $(TEST_APP)/Contents/MacOS/pi-launcher
 PI_VERSION := $(shell python3 -c "import json; print(json.load(open('packaging/pi-release.json'))['version'])")
 
-.PHONY: all fetch app test-app test test-functional test-pty test-smoke verify clean
+.PHONY: all fetch app test-app test test-icon test-functional test-pty test-smoke verify clean
 
 all: app
 
@@ -33,7 +33,10 @@ test-app:
 	  APP_DIR="$(CURDIR)/$(TEST_APP)" \
 	  scripts/build-app.sh
 
-test: test-functional test-pty test-smoke
+test: test-icon test-functional test-pty test-smoke
+
+test-icon: app
+	python3 tests/icon_contract.py "$(APP)"
 
 test-functional: test-app
 	python3 tests/functional.py "$(TEST_LAUNCHER_EXE)"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 <h3 align="center">Run Pi in your terminal under a stable, signed macOS app identity.</h3>
 
+**Independent project:** pi-launcher is an independent, unofficial launcher for Pi. It is not affiliated with or endorsed by the Pi maintainers.
+
 The official [Pi](https://github.com/earendil-works/pi) standalone macOS binary ships ad-hoc signed: Gatekeeper rejects it, and any tool that binds trust to a code-signed app identity has nothing stable to attach to. In my setup that tool is [Automic Vault](https://www.automicvault.com), which approves credential access by walking the process ancestry and matching designated requirements. An ad-hoc `a.out` signature gives it a different cdhash on every build.
 
 pi-launcher is the smallest fix: a signed, notarized `Pi Launcher.app` whose only executable does one thing - spawn the one official Pi binary bundled inside the same app, then stay alive as its parent in your existing terminal. No GUI, no PTY, no new window. Your terminal session stays exactly as it was; the process ancestry gains a stable signed identity.
@@ -93,7 +95,7 @@ There are no launcher flags. Every argument is passed to Pi byte-for-byte, inclu
 
 - macOS arm64 only (that's what upstream's standalone binary targets).
 - One pinned Pi version per pi-launcher release. Upgrading Pi means a new pi-launcher release; the app does not self-update.
-- Not an official Pi distribution. Pi is Mario Zechner's project; this is an independent wrapper. Report Pi behavior issues upstream, launcher issues here.
+- Pi remains Mario Zechner's project. Report Pi behavior issues upstream, launcher issues here.
 - A signed parent is necessary but not sufficient for Automic Vault recognition: whether Automic binds policy to this app identity is still unproven until the attended live test runs. The identity exists; don't assume the policy match.
 
 ## Verify a Release

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -8,10 +8,14 @@
 	<string>pi-launcher</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.kunchenguid.pi-launcher</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>Pi Launcher</string>
+	<key>CFBundleGetInfoString</key>
+	<string>Pi Launcher is an independent, unofficial launcher for Pi. It is not affiliated with or endorsed by the Pi maintainers.</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -23,6 +27,6 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2026 Kun Chen. Pi is developed by Mario Zechner (MIT).</string>
+	<string>Copyright © 2026 Kun Chen. Pi Launcher is an independent, unofficial launcher for Pi. It is not affiliated with or endorsed by the Pi maintainers. Pi is developed by Mario Zechner (MIT).</string>
 </dict>
 </plist>

--- a/packaging/icon/AppIcon.svg
+++ b/packaging/icon/AppIcon.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <title>Pi Launcher app icon</title>
+  <!-- Original pi-launcher artwork. No Pi press-kit artwork is used. -->
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <rect x="112" y="112" width="800" height="800" rx="186" fill="url(#background)"/>
+  <path
+    d="M330 348 L532 512 L330 676"
+    fill="none"
+    stroke="#fff"
+    stroke-width="112"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M608 648 L800 648"
+    fill="none"
+    stroke="#fff"
+    stroke-width="104"
+    stroke-linecap="round"
+  />
+</svg>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -16,6 +16,7 @@ VERSION="${VERSION:-0.0.0-dev}"
 PAYLOAD_DIR="${PAYLOAD_DIR:-$REPO_ROOT/build/vendor/pi-tree/pi}"
 APP_DIR="${APP_DIR:-$REPO_ROOT/build/Pi Launcher.app}"
 LAUNCHER_BIN="$REPO_ROOT/build/pi-launcher"
+ICON_FILE="$REPO_ROOT/build/AppIcon.icns"
 
 if [[ ! -x "$PAYLOAD_DIR/pi" ]]; then
   echo "build-app: FAIL: payload $PAYLOAD_DIR has no executable pi (run scripts/fetch-pi.sh first)" >&2
@@ -29,6 +30,10 @@ clang \
   -arch arm64 -mmacosx-version-min=13.0 \
   -o "$LAUNCHER_BIN" \
   "$REPO_ROOT/src/pi-launcher.c"
+
+# Generate the original app icon. The iconset and icns stay under the
+# ignored build tree.
+"$REPO_ROOT/scripts/build-icon.sh" "$ICON_FILE"
 
 rm -rf "$APP_DIR"
 mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources"
@@ -44,6 +49,7 @@ chmod 755 "$APP_DIR/Contents/MacOS/pi-launcher"
 rm -rf "$APP_DIR/Contents/Resources/pi"
 cp -R "$PAYLOAD_DIR" "$APP_DIR/Contents/Resources/pi"
 cp "$REPO_ROOT/packaging/THIRD-PARTY-NOTICES.md" "$APP_DIR/Contents/Resources/THIRD-PARTY-NOTICES.md"
+cp "$ICON_FILE" "$APP_DIR/Contents/Resources/AppIcon.icns"
 
 # Ad-hoc sign nested code first, then the outer bundle, so the development
 # app is coherent and runnable on Apple Silicon. Release builds re-sign

--- a/scripts/build-icon.sh
+++ b/scripts/build-icon.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# build-icon.sh - render the original SVG app icon into a macOS icns.
+#
+# The SVG is the source of truth. All PNG iconset intermediates and the icns
+# are generated under build/ and remain untracked.
+#
+# Usage: build-icon.sh [output.icns]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE="$REPO_ROOT/packaging/icon/AppIcon.svg"
+OUTPUT="${1:-$REPO_ROOT/build/AppIcon.icns}"
+
+if [[ "$OUTPUT" != *.icns ]]; then
+  echo "build-icon: FAIL: output must end in .icns" >&2
+  exit 1
+fi
+if [[ ! -f "$SOURCE" ]]; then
+  echo "build-icon: FAIL: source icon missing at $SOURCE" >&2
+  exit 1
+fi
+
+ICONSET="${OUTPUT%.icns}.iconset"
+rm -rf "$ICONSET" "$OUTPUT"
+mkdir -p "$ICONSET"
+
+render() {
+  local name="$1" pixels="$2"
+  /usr/bin/sips -s format png -z "$pixels" "$pixels" \
+    "$SOURCE" --out "$ICONSET/$name" >/dev/null
+}
+
+render icon_16x16.png 16
+render icon_16x16@2x.png 32
+cp "$ICONSET/icon_16x16@2x.png" "$ICONSET/icon_32x32.png"
+render icon_32x32@2x.png 64
+render icon_128x128.png 128
+render icon_128x128@2x.png 256
+cp "$ICONSET/icon_128x128@2x.png" "$ICONSET/icon_256x256.png"
+render icon_256x256@2x.png 512
+cp "$ICONSET/icon_256x256@2x.png" "$ICONSET/icon_512x512.png"
+render icon_512x512@2x.png 1024
+
+/usr/bin/iconutil -c icns "$ICONSET" -o "$OUTPUT"
+echo "build-icon: generated $OUTPUT"

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -156,6 +156,7 @@ ci_yml = (ROOT / ".github/workflows/ci.yml").read_text()
 check(
     "ci.yml runs the full test suite on pull_request",
     "pull_request:" in ci_yml
+    and "make test-icon" in ci_yml
     and "make test-functional" in ci_yml
     and "make test-pty" in ci_yml
     and "make test-smoke" in ci_yml,

--- a/scripts/verify-app.sh
+++ b/scripts/verify-app.sh
@@ -30,6 +30,8 @@ fi
 EXPECTED_BUNDLE_ID="com.kunchenguid.pi-launcher"
 EXPECTED_TEAM_ID="9T2J7MNUP9"
 EXPECTED_EXECUTABLE="pi-launcher"
+EXPECTED_ICON_FILE="AppIcon"
+EXPECTED_DISCLAIMER="It is not affiliated with or endorsed by the Pi maintainers."
 
 fail() {
   echo "verify-app: FAIL: $1" >&2
@@ -50,6 +52,14 @@ plist_get() {
   || fail "CFBundleExecutable mismatch"
 [[ "$(plist_get CFBundlePackageType)" == "APPL" ]] \
   || fail "CFBundlePackageType is not APPL"
+[[ "$(plist_get CFBundleIconFile)" == "$EXPECTED_ICON_FILE" ]] \
+  || fail "CFBundleIconFile must be $EXPECTED_ICON_FILE"
+[[ "$(plist_get CFBundleGetInfoString)" == *"independent, unofficial launcher for Pi"* ]] \
+  || fail "CFBundleGetInfoString must identify the independent, unofficial launcher"
+[[ "$(plist_get CFBundleGetInfoString)" == *"$EXPECTED_DISCLAIMER"* ]] \
+  || fail "CFBundleGetInfoString is missing the non-affiliation disclaimer"
+[[ "$(plist_get NSHumanReadableCopyright)" == *"$EXPECTED_DISCLAIMER"* ]] \
+  || fail "NSHumanReadableCopyright is missing the non-affiliation disclaimer"
 [[ "$(plist_get LSUIElement)" == "true" ]] \
   || fail "LSUIElement must be true (agent app, no Dock presence)"
 [[ -x "$APP_DIR/Contents/MacOS/pi-launcher" ]] \
@@ -60,6 +70,11 @@ plist_get() {
   || fail "upstream MIT LICENSE missing from bundle"
 [[ -f "$APP_DIR/Contents/Resources/THIRD-PARTY-NOTICES.md" ]] \
   || fail "THIRD-PARTY-NOTICES.md missing from bundle"
+ICON_PATH="$APP_DIR/Contents/Resources/$EXPECTED_ICON_FILE.icns"
+[[ -f "$ICON_PATH" ]] \
+  || fail "$EXPECTED_ICON_FILE.icns missing from bundle"
+file -b "$ICON_PATH" | grep -q "^Mac OS X icon" \
+  || fail "$EXPECTED_ICON_FILE.icns is not a valid macOS icon"
 
 # ---- Architecture: every Mach-O in the bundle must be arm64 ----
 MACH_O_COUNT=0

--- a/tests/icon_contract.py
+++ b/tests/icon_contract.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Verify the app icon resource and independent-project metadata contract.
+
+Usage: icon_contract.py <path-to-app-bundle>
+"""
+
+import plistlib
+import struct
+import sys
+from pathlib import Path
+
+APP = Path(sys.argv[1]).resolve() if len(sys.argv) == 2 else None
+if APP is None or not APP.is_dir():
+    print("usage: icon_contract.py <path-to-app-bundle>", file=sys.stderr)
+    sys.exit(2)
+
+FAILURES = []
+PASSES = []
+EXPECTED_INFO = (
+    "Pi Launcher is an independent, unofficial launcher for Pi. "
+    "It is not affiliated with or endorsed by the Pi maintainers."
+)
+
+
+def check(name, condition, detail=""):
+    if condition:
+        PASSES.append(name)
+        print(f"PASS {name}")
+    else:
+        FAILURES.append(name)
+        print(f"FAIL {name} {detail}")
+
+
+plist_path = APP / "Contents" / "Info.plist"
+try:
+    with plist_path.open("rb") as f:
+        info = plistlib.load(f)
+except (OSError, plistlib.InvalidFileException) as exc:
+    print(f"icon-contract: cannot read {plist_path}: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+check(
+    "icon declaration names AppIcon",
+    info.get("CFBundleIconFile") == "AppIcon",
+    f"got {info.get('CFBundleIconFile')!r}",
+)
+check(
+    "bundle info identifies the independent, unofficial launcher",
+    info.get("CFBundleGetInfoString") == EXPECTED_INFO,
+    f"got {info.get('CFBundleGetInfoString')!r}",
+)
+check(
+    "copyright metadata carries the non-affiliation disclaimer",
+    EXPECTED_INFO in info.get("NSHumanReadableCopyright", ""),
+    f"got {info.get('NSHumanReadableCopyright')!r}",
+)
+
+icon_path = APP / "Contents" / "Resources" / "AppIcon.icns"
+check("declared icon resource exists", icon_path.is_file(), str(icon_path))
+
+icon_types = set()
+parse_error = None if icon_path.is_file() else "icon resource is missing"
+if icon_path.is_file():
+    try:
+        data = icon_path.read_bytes()
+        if len(data) < 8 or data[:4] != b"icns":
+            raise ValueError("missing icns header")
+        declared_size = struct.unpack(">I", data[4:8])[0]
+        if declared_size != len(data):
+            raise ValueError(
+                f"header size {declared_size} does not match file size {len(data)}"
+            )
+        offset = 8
+        while offset < len(data):
+            if offset + 8 > len(data):
+                raise ValueError("truncated chunk header")
+            chunk_type = data[offset:offset + 4].decode("ascii")
+            chunk_size = struct.unpack(">I", data[offset + 4:offset + 8])[0]
+            if chunk_size < 8 or offset + chunk_size > len(data):
+                raise ValueError(f"invalid {chunk_type!r} chunk size {chunk_size}")
+            icon_types.add(chunk_type)
+            offset += chunk_size
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        parse_error = str(exc)
+
+check("icon resource is a valid icns container", parse_error is None, parse_error or "")
+
+# Each entry is a standard macOS point size and its Retina representation.
+# iconutil may encode 16/32 px legacy entries as ic04/ic05 or icp4/icp5.
+required_entries = {
+    "16x16": {"ic04", "icp4"},
+    "16x16@2x": {"ic11"},
+    "32x32": {"ic05", "icp5"},
+    "32x32@2x": {"ic12", "icp6"},
+    "128x128": {"ic07"},
+    "128x128@2x": {"ic13"},
+    "256x256": {"ic08"},
+    "256x256@2x": {"ic14"},
+    "512x512": {"ic09"},
+    "512x512@2x": {"ic10"},
+}
+missing = [
+    label for label, alternatives in required_entries.items()
+    if icon_types.isdisjoint(alternatives)
+]
+check(
+    "icon contains every standard and Retina size",
+    not missing,
+    f"missing={missing} chunks={sorted(icon_types)}",
+)
+
+print()
+print(f"icon-contract: {len(PASSES)} passed, {len(FAILURES)} failed")
+sys.exit(1 if FAILURES else 0)


### PR DESCRIPTION
## Summary

- replace the generic macOS app icon with original terminal-prompt artwork
- generate a complete `.icns` from the committed SVG using macOS `sips` and `iconutil`; PNG/iconset intermediates stay under ignored `build/`
- declare the icon and independent-project disclaimer in standard bundle metadata
- move the same disclaimer to the top of the public README
- gate the declaration, resource, every standard/Retina icon size, and metadata in CI and release verification

No launcher behavior, bundled Pi version, bundle identifier, signing identity, entitlements, architecture, Homebrew contract, or release flow changed.

## Baseline reproduced

I built `v1.0.0` from the tag. Its `Info.plist` has no `CFBundleIconFile`, and `Contents/Resources` has no `.icns` resource, so macOS falls back to the generic application icon. The new focused contract test fails that baseline on all six icon/metadata assertions and passes the corrected bundle.

## Pi brand evidence and decision

Authoritative source inspected: [Pi Press Kit](https://pi.dev/press-kit).

Exact published terms:

- page scope: **"Assets and contact for press coverage."**
- [primary logo](https://pi.dev/logo.svg): **"Vector logo for light/dark usage and editorial placements."**
- [badge](https://pi.dev/favicon.svg): **"Square mark for favicons and compact badges."**
- screenshots: **"Use these visuals in articles, videos, and conference slides."**

The rendered press-kit page links no usage, trademark, license, attribution, or brand-policy page. It gives no permission for using Pi artwork as an independent third-party app identity, and no modification, spacing, attribution, trademark, or endorsement terms for that use. The footer says **"MIT License"** but does not link that statement or apply it to the press-kit artwork. The [upstream software license](https://github.com/earendil-works/pi/blob/main/LICENSE) is MIT, but I found no official source extending it to these brand assets.

Using the official logo or badge as this app's icon could also reasonably imply official status. I therefore did not copy or modify any of the press-kit artwork. `packaging/icon/AppIcon.svg` is original artwork: a generic terminal prompt on an indigo-to-cyan background, visually distinct from Pi's blocky white-on-black monogram. Since no official artwork is used, there is no asset attribution or spacing requirement to apply.

## Validation

- `make test` (icon/metadata contract, 13 functional checks, 18 PTY checks, bundled-Pi smoke)
- `python3 scripts/check-release-contract.py`
- `shellcheck -S warning scripts/*.sh`
- `ruff check tests/icon_contract.py scripts/check-release-contract.py`
- `xmllint --noout packaging/Info.plist packaging/icon/AppIcon.svg`
- `codesign --verify --deep --strict` on the built app and a fresh zip extraction
- `scripts/verify-app.sh` on the built app and fresh zip extraction, including arm64 architecture
- `.icns` round-trip through `iconutil` confirms 16, 32, 64, 128, 256, 512, and 1024 px representations with alpha
- visual inspection at 16, 32, 64, 128, 256, 512, and 1024 px on light and dark backgrounds: no clipping, unintended transparency, edge halos, blur, or contrast problems
