### PR TITLE
feat: automate Homebrew cask updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           ZIP_NAME="Pi-Launcher-${RELEASE_VERSION}.zip"
           echo "zip_name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
+          VERSION_REF='#{version}'
+          CASK_TAG_NAME="${TAG_NAME/$RELEASE_VERSION/$VERSION_REF}"
+          CASK_ZIP_NAME="${ZIP_NAME/$RELEASE_VERSION/$VERSION_REF}"
+          echo "cask_download_url=https://github.com/$GITHUB_REPOSITORY/releases/download/$CASK_TAG_NAME/$CASK_ZIP_NAME" >> "$GITHUB_OUTPUT"
           echo "Releasing pi-launcher $RELEASE_VERSION from $TAG_NAME"
 
       - name: Restore App Store Connect API key
@@ -236,12 +240,15 @@ jobs:
           scripts/verify-app.sh "$EXTRACT_DIR/$APP_NAME" --signed --gatekeeper
 
       - name: Compute artifact checksum
+        id: checksum
         env:
           ZIP_NAME: ${{ steps.version.outputs.zip_name }}
         run: |
           set -euo pipefail
           (cd "$(dirname "$dist_zip")" && shasum -a 256 "$ZIP_NAME" | tee "$ZIP_NAME.sha256")
           cat "$dist_zip.sha256"
+          SHA256="$(awk '{print $1}' "$dist_zip.sha256")"
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
 
       - name: Publish the GitHub release
         env:
@@ -283,6 +290,51 @@ jobs:
           ditto -x -k "$DOWNLOAD_DIR/$ZIP_NAME" "$EXTRACT_DIR"
           scripts/verify-app.sh "$EXTRACT_DIR/$APP_NAME" --signed --gatekeeper
           echo "Published artifact verified: $ZIP_NAME ($PUBLISHED_SHA)"
+
+      - name: Update Homebrew Cask
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.release_version }}
+          SHA256: ${{ steps.checksum.outputs.sha256 }}
+          DOWNLOAD_URL: ${{ steps.version.outputs.cask_download_url }}
+        run: |
+          set -euo pipefail
+          : "${HOMEBREW_TAP_TOKEN:?Missing HOMEBREW_TAP_TOKEN}"
+          git_with_tap_auth() {
+            git \
+              -c credential.helper= \
+              -c 'credential.helper=!f() { printf "%s\\n" "username=x-access-token" "password=$HOMEBREW_TAP_TOKEN"; }; f' \
+              "$@"
+          }
+          git_with_tap_auth clone "https://github.com/kunchenguid/homebrew-tap.git" "$RUNNER_TEMP/homebrew-tap"
+          mkdir -p "$RUNNER_TEMP/homebrew-tap/Casks"
+          cat > "$RUNNER_TEMP/homebrew-tap/Casks/pi-launcher.rb" << CASK_EOF
+          cask "pi-launcher" do
+            version "${VERSION}"
+            sha256 "${SHA256}"
+
+            url "${DOWNLOAD_URL}"
+            name "Pi Launcher"
+            desc "Run the bundled Pi CLI under a stable, signed app identity"
+            homepage "https://github.com/kunchenguid/pi-launcher"
+
+            depends_on arch: :arm64
+            depends_on macos: :ventura
+
+            app "Pi Launcher.app"
+            binary "#{appdir}/Pi Launcher.app/Contents/MacOS/pi-launcher", target: "pi-signed"
+
+            uninstall quit: "com.kunchenguid.pi-launcher"
+          end
+          CASK_EOF
+          cd "$RUNNER_TEMP/homebrew-tap"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/pi-launcher.rb
+          if ! git diff --cached --quiet; then
+            git commit -m "pi-launcher ${VERSION}"
+            git_with_tap_auth push
+          fi
 
       - name: Remove the signing keychain
         if: always()

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -9,10 +9,11 @@ Checks, in order:
   3. .github/workflows/release.yml has every required gate, in order
   4. release.yml references exactly the canonical secret names
   5. release.yml pins the canonical Team ID and bundle ID
-  6. release-please is anchored at v1.1.0 and calls the signed release workflow
-  7. .github/workflows/ci.yml runs the test suite on pull requests
-  8. homebrew/pi-launcher.rb matches the release artifact contract
-  9. no private key material anywhere in the tracked tree
+  6. Homebrew tap updates only after the published artifact is verified
+  7. release-please is anchored at v1.1.0 and calls the signed release workflow
+  8. .github/workflows/ci.yml runs the test suite on pull requests
+  9. homebrew/pi-launcher.rb matches the release artifact contract
+  10. no private key material anywhere in the tracked tree
 """
 
 import json
@@ -137,6 +138,7 @@ canonical = {
     "MAC_DEVELOPER_ID_CERT_P12",
     "MAC_DEVELOPER_ID_CERT_PASSWORD",
     "GITHUB_TOKEN",
+    "HOMEBREW_TAP_TOKEN",
 }
 check(
     "release.yml references exactly the canonical secrets",
@@ -152,7 +154,69 @@ check(
     and "Developer ID Application: Kun Chen (9T2J7MNUP9)" in release_yml,
 )
 
-# ---- 6. release-please handoff ----
+# ---- 6. Homebrew tap handoff ----
+publish_pos = release_yml.find("- name: Publish the GitHub release")
+published_verify_pos = release_yml.find("- name: Verify the published artifact")
+homebrew_pos = release_yml.find("- name: Update Homebrew Cask")
+cleanup_pos = release_yml.find("- name: Remove the signing keychain")
+check(
+    "Homebrew update runs only after publication and published-artifact verification",
+    -1 not in (publish_pos, published_verify_pos, homebrew_pos, cleanup_pos)
+    and publish_pos < published_verify_pos < homebrew_pos < cleanup_pos,
+)
+check(
+    "Homebrew update consumes the release version, URL, and checksum outputs",
+    'VERSION: ${{ steps.version.outputs.release_version }}' in release_yml
+    and 'SHA256: ${{ steps.checksum.outputs.sha256 }}' in release_yml
+    and 'DOWNLOAD_URL: ${{ steps.version.outputs.cask_download_url }}' in release_yml
+    and 'echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"' in release_yml
+    and 'CASK_TAG_NAME="${TAG_NAME/$RELEASE_VERSION/$VERSION_REF}"' in release_yml
+    and 'CASK_ZIP_NAME="${ZIP_NAME/$RELEASE_VERSION/$VERSION_REF}"' in release_yml,
+)
+check(
+    "Homebrew tap credentials are ephemeral and absent from the remote URL",
+    'git_with_tap_auth clone "https://github.com/kunchenguid/homebrew-tap.git"'
+    in release_yml
+    and "password=$HOMEBREW_TAP_TOKEN" in release_yml
+    and "x-access-token:${HOMEBREW_TAP_TOKEN}@" not in release_yml,
+)
+expected_generated_cask = '''cask "pi-launcher" do
+  version "${VERSION}"
+  sha256 "${SHA256}"
+
+  url "${DOWNLOAD_URL}"
+  name "Pi Launcher"
+  desc "Run the bundled Pi CLI under a stable, signed app identity"
+  homepage "https://github.com/kunchenguid/pi-launcher"
+
+  depends_on arch: :arm64
+  depends_on macos: :ventura
+
+  app "Pi Launcher.app"
+  binary "#{appdir}/Pi Launcher.app/Contents/MacOS/pi-launcher", target: "pi-signed"
+
+  uninstall quit: "com.kunchenguid.pi-launcher"
+end
+'''
+heredoc_match = re.search(
+    r'cat > "\$RUNNER_TEMP/homebrew-tap/Casks/pi-launcher\.rb" << CASK_EOF\n'
+    r'(?P<body>.*?)'
+    r'^          CASK_EOF$',
+    release_yml,
+    re.MULTILINE | re.DOTALL,
+)
+generated_cask = ""
+if heredoc_match:
+    generated_cask = "\n".join(
+        line.removeprefix("          ")
+        for line in heredoc_match.group("body").splitlines()
+    ) + "\n"
+check(
+    "Homebrew generator preserves the seeded pi-launcher cask structure",
+    generated_cask == expected_generated_cask,
+)
+
+# ---- 7. release-please handoff ----
 release_please_config = json.loads((ROOT / "release-please-config.json").read_text())
 release_please_manifest = json.loads(
     (ROOT / ".release-please-manifest.json").read_text()
@@ -187,7 +251,7 @@ check(
     and "description: Release tag created by release-please" in release_yml,
 )
 
-# ---- 7. ci.yml runs tests on PRs without secrets ----
+# ---- 8. ci.yml runs tests on PRs without secrets ----
 ci_yml = (ROOT / ".github/workflows/ci.yml").read_text()
 check(
     "ci.yml runs the full test suite on pull_request",
@@ -202,7 +266,7 @@ check(
     "MAC_DEVELOPER_ID" not in ci_yml and "APP_STORE_CONNECT" not in ci_yml,
 )
 
-# ---- 8. Homebrew cask template matches the release contract ----
+# ---- 9. Homebrew cask template matches the release contract ----
 cask = (ROOT / "homebrew/pi-launcher.rb").read_text()
 check(
     "cask url matches the release asset naming",
@@ -219,7 +283,7 @@ check(
     'sha256 "REPLACE_WITH_RELEASE_ZIP_SHA256"' in cask,
 )
 
-# ---- 9. no private key material in the tree ----
+# ---- 10. no private key material in the tree ----
 tracked = subprocess.run(
     ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True
 ).stdout.split()


### PR DESCRIPTION
## Summary

- derive the Homebrew download URL and checksum from the same release facts used to publish the verified artifact
- update `Casks/pi-launcher.rb` only after the published artifact passes verification
- preserve the seeded cask structure, including the `pi-signed` binary name, and use ephemeral tap credentials
- extend the secret-free release contract checks to enforce ordering, output wiring, credentials, and cask structure

## Validation

- `make test`
- `python3 scripts/check-release-contract.py`
- parsed `.github/workflows/release.yml` as YAML
- generated the cask with v1.1.0 release facts and confirmed an exact match with the seeded `kunchenguid/homebrew-tap` file

No release was cut and the tap was not modified. True end-to-end proof will occur on the next real release.