### PR TITLE
chore(ci): skip pull_request CI for release-please output-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: CI
 
 on:
+  # release-please opens its release PR with GITHUB_TOKEN, which creates a
+  # pull_request run that can only sit in action_required. Its output set is
+  # exactly these three files, so excluding them means no run is ever created.
   pull_request:
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - version.txt
   push:
     branches:
       - main
@@ -17,6 +24,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - name: Assert release-please PR CI exclusions
+        run: bash scripts/check-release-ci-exclusions.sh
 
       - name: Lint shell scripts
         run: |
@@ -59,5 +69,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
+      - name: Assert release-please PR CI exclusions
+        run: bash scripts/check-release-ci-exclusions.sh
+
       - name: Check release contracts
         run: python3 scripts/check-release-contract.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ pi-launcher: a minimal signed macOS app whose executable spawns the one bundled 
 - `tests/probe.c` + `tests/functional.py` + `tests/pty_tests.py` - probe-payload test double driven through real PTYs; `make test` runs everything including the bundled-Pi smoke.
 - `scripts/` - fetch/build/sign/verify pipeline; `check-release-contract.py` is the secret-free CI gate for workflow/packaging changes.
 - `packaging/icon/AppIcon.svg` - source for the original app icon; `scripts/build-icon.sh` renders the iconset and icns under ignored `build/`. Do not substitute Pi brand assets without explicit third-party app-branding permission.
-- `.github/workflows/` - `ci.yml` runs PR tests without secrets. `release-please.yml` owns versions, changelog, and tags, then calls reusable `release.yml` for the signed/notarized build; manual tag and dispatch recovery paths remain. See `RELEASE.md`.
+- `.github/workflows/` - `ci.yml` runs PR tests without secrets; its `pull_request.paths-ignore` excludes the simple-strategy release-please outputs (`.release-please-manifest.json`, `CHANGELOG.md`, `version.txt`) so release PRs create zero runs, enforced by `scripts/check-release-ci-exclusions.sh`. `release-please.yml` owns versions, changelog, and tags, then calls reusable `release.yml` for the signed/notarized build; manual tag and dispatch recovery paths remain. See `RELEASE.md`.
 - `homebrew/pi-launcher.rb` - cask contract for the separate tap task; never publish from this repo.
 - Team ID `9T2J7MNUP9`, bundle id `com.kunchenguid.pi-launcher`, app `Pi Launcher.app`, asset `Pi-Launcher-<version>.zip`.
 

--- a/scripts/check-release-ci-exclusions.sh
+++ b/scripts/check-release-ci-exclusions.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Assert every pull_request workflow excludes the config-derived release-please
+# output set, so release PRs create zero CI runs instead of action_required ones.
+#
+# Derives the expected paths from release-please-config.json (release-type,
+# changelog-path, version-file, extra-files) plus the manifest path, then checks
+# each workflow's pull_request.paths-ignore (or negated paths entries) is a
+# superset. Dependency-free: ruby + stdlib only.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+ruby -ryaml -rjson -e '
+  config = JSON.parse(File.read("release-please-config.json"))
+  packages = config.fetch("packages")
+
+  expected = []
+  packages.each do |pkg_path, pkg|
+    pkg = {} unless pkg.is_a?(Hash)
+    release_type = pkg["release-type"] || config["release-type"] || "node"
+    changelog = pkg["changelog-path"] || config["changelog-path"] || "CHANGELOG.md"
+    prefix = pkg_path == "." ? "" : pkg_path.sub(%r{/*\z}, "/")
+
+    expected << "#{prefix}#{changelog}"
+    case release_type
+    when "simple"
+      version_file = pkg["version-file"] || config["version-file"] || "version.txt"
+      expected << "#{prefix}#{version_file}"
+    when "node"
+      expected << "#{prefix}package.json"
+      lock = "#{prefix}package-lock.json"
+      expected << lock if File.exist?(lock)
+    when "go"
+      # changelog only by default
+    else
+      abort "unsupported release-please release-type for ignore derivation: #{release_type}"
+    end
+
+    extra = pkg["extra-files"] || []
+    extra.each do |entry|
+      path = entry.is_a?(Hash) ? entry["path"] : entry
+      next if path.nil? || path.to_s.empty?
+      expected << (pkg_path == "." ? path.to_s : "#{prefix}#{path}")
+    end
+  end
+
+  root_extra = config["extra-files"] || []
+  root_extra.each do |entry|
+    path = entry.is_a?(Hash) ? entry["path"] : entry
+    expected << path.to_s if path && !path.to_s.empty?
+  end
+
+  manifest = ".release-please-manifest.json"
+  Dir.glob(".github/workflows/*.{yml,yaml}").each do |wf_path|
+    text = File.read(wf_path)
+    text.scan(/manifest-file:\s*(\S+)/) { |m| manifest = m[0] }
+  end
+  expected << manifest
+  expected = expected.map(&:to_s).uniq.sort
+
+  pr_workflows = []
+  Dir.glob(".github/workflows/*.{yml,yaml}").sort.each do |wf_path|
+    wf = YAML.load_file(wf_path)
+    on = wf[true] || wf["on"]
+    next unless on.is_a?(Hash) && on.key?("pull_request")
+    pr_workflows << [wf_path, on["pull_request"]]
+  end
+
+  if pr_workflows.empty?
+    abort "no pull_request workflows found under .github/workflows/"
+  end
+
+  failures = []
+  pr_workflows.each do |wf_path, pr|
+    covered = []
+    case pr
+    when nil, true, Array
+      # bare pull_request: or list form - no path filter
+      covered = []
+    when Hash
+      if pr.key?("paths") && pr.key?("paths-ignore")
+        failures << "#{wf_path}: pull_request must not combine paths with paths-ignore"
+        next
+      end
+      if pr.key?("paths-ignore")
+        ignore = Array(pr["paths-ignore"]).map(&:to_s)
+        covered = ignore
+      elsif pr.key?("paths")
+        # Negated entries (!path) after positives exclude those paths.
+        covered = Array(pr["paths"]).map(&:to_s).select { |p| p.start_with?("!") }.map { |p| p.delete_prefix("!") }
+      end
+    else
+      failures << "#{wf_path}: pull_request trigger has unexpected shape: #{pr.inspect}"
+      next
+    end
+
+    missing = expected.reject { |path| covered.include?(path) }
+    unless missing.empty?
+      failures << "#{wf_path}: pull_request path filter missing release-please outputs: #{missing.join(", ")} (expected #{expected.join(", ")}; have #{covered.join(", ")})"
+    end
+  end
+
+  if failures.empty?
+    puts "release-please CI exclusions ok (#{expected.join(", ")}) across #{pr_workflows.map(&:first).join(", ")}"
+    exit 0
+  end
+
+  failures.each { |f| warn f }
+  exit 1
+'


### PR DESCRIPTION
## Summary

Release-please opens its release PR with `GITHUB_TOKEN`, which since 2026-07-01 creates `pull_request` workflow runs that sit in `action_required` forever. This PR makes those runs never get created.

- Add `pull_request.paths-ignore` on `ci.yml` for the simple-strategy output set: `.release-please-manifest.json`, `CHANGELOG.md`, `version.txt`.
- Leave `push` / `workflow_dispatch` (and the separate release-please + signed-release workflows) unchanged.
- Add `scripts/check-release-ci-exclusions.sh`, a dependency-free config-derived drift assertion wired as an early step in both CI jobs, so a future `extra-files` or strategy change fails loudly if the ignore set is not updated.

## Validation (local)

- YAML parse: `on` keys remain `pull_request`, `push`, `workflow_dispatch`; paths-ignore is exactly the three release outputs.
- Drift check passes on the patched file and fails if `paths-ignore` is removed.
- Offline file-list simulation: release-output-only lists produce zero run; ordinary PR file lists (src/tests, workflow+script, packaging pin, docs, Makefile) still run.
- `scripts/check-release-contract.py` still passes.
- Commit type is `chore(ci)` so release-please will not cut a release from this change.

## Notes

- No dispatcher, token, ruleset, or synthetic release.
- Irreducible GitHub limitation: a human PR that changes *only* those three files also gets zero PR CI; post-merge `push` to `main` still runs CI.
- Per fleet scout `release-please-ci-fleet-scout-r1` / Wave 1.