### PR TITLE
fix: bundle Pi 0.83.0

### DIFF
--- a/packaging/pi-release.json
+++ b/packaging/pi-release.json
@@ -1,10 +1,10 @@
 {
   "upstream": "https://github.com/earendil-works/pi",
-  "tag": "v0.82.0",
-  "version": "0.82.0",
-  "url": "https://github.com/earendil-works/pi/releases/download/v0.82.0/pi-darwin-arm64.tar.gz",
-  "sha256": "6205debd0071ff56d765e0ee941f087f9a18d1f6c2f7dea17bdc8f97ff3cf9c1",
-  "sumsUrl": "https://github.com/earendil-works/pi/releases/download/v0.82.0/SHA256SUMS",
-  "licenseUrl": "https://raw.githubusercontent.com/earendil-works/pi/v0.82.0/LICENSE",
+  "tag": "v0.83.0",
+  "version": "0.83.0",
+  "url": "https://github.com/earendil-works/pi/releases/download/v0.83.0/pi-darwin-arm64.tar.gz",
+  "sha256": "147fc3c451ec543a15102af251ce316079c8fcadfe8ae4d3ffee202346e9bed9",
+  "sumsUrl": "https://github.com/earendil-works/pi/releases/download/v0.83.0/SHA256SUMS",
+  "licenseUrl": "https://raw.githubusercontent.com/earendil-works/pi/v0.83.0/LICENSE",
   "licenseSha256": "0457f5bcec3b3b211605dfb5d1a49042fd638f3686a410fe099c24a25af13c48"
 }


### PR DESCRIPTION
## Intent

用户要求把当前默认的签名版 Pi Launcher 从内置 Pi 0.82.0 更新到最新 Pi 0.83.0，同时保留原有稳定的 macOS Developer ID 签名身份。必须通过正式发布流程重新签名、公证并发布，不能直接篡改已安装 App。此变更只更新 packaging/pi-release.json 中固定的上游版本、URL 与经官方 SHA256SUMS 交叉核验的 arm64 校验和，不修改 launcher 安全边界。

## What Changed

- Update the bundled Pi release pin from 0.82.0 to 0.83.0.
- Refresh the arm64 release, checksum manifest, and license URLs, along with the officially verified archive SHA256.

## Risk Assessment

✅ Low: 变更严格限定于 Pi 0.83.0 的版本清单，官方 SHA256SUMS 中的 arm64 校验和及许可证哈希均与清单一致，且未改变启动器安全边界或既有签名、公证和发布流程。

## Testing

核对了基线差异，运行完整自动化测试和发布契约测试，并通过真实 Launcher 验证 Pi 0.83.0、参数传递及官方摘要；证据已保存且工作树已清理，但正式签名、公证和发布仍需发布工作流产物佐证。

<details>
<summary>Evidence: Pi 0.83.0 端到端验证记录</summary>

`Launcher 输出 0.83.0；下载包、官方 SHA256SUMS 与固定清单的摘要均为 147fc3c451ec543a15102af251ce316079c8fcadfe8ae4d3ffee202346e9bed9；同时记录了固定 Developer ID 身份和发布门禁顺序。`

```text
$ build/Pi Launcher.app/Contents/MacOS/pi-launcher --version
0.83.0

$ build/Pi Launcher.app/Contents/MacOS/pi-launcher -p --model invalid/model "say hi"
Error: Model "invalid/model" not found. Use --list-models to see available models.

$ shasum -a 256 build/vendor/pi-darwin-arm64.tar.gz
147fc3c451ec543a15102af251ce316079c8fcadfe8ae4d3ffee202346e9bed9  build/vendor/pi-darwin-arm64.tar.gz
$ upstream SHA256SUMS entry
147fc3c451ec543a15102af251ce316079c8fcadfe8ae4d3ffee202346e9bed9  pi-darwin-arm64.tar.gz
$ pinned manifest version and checksum
0.83.0 147fc3c451ec543a15102af251ce316079c8fcadfe8ae4d3ffee202346e9bed9

$ release identity and ordered gates
  TEAM_ID: 9T2J7MNUP9
  SIGN_IDENTITY: "Developer ID Application: Kun Chen (9T2J7MNUP9)"
    name: Build, sign, notarize, and publish
      - name: Sign nested code, then the outer app
      - name: Notarize
      - name: Staple and build the distribution zip
      - name: Verify the publication-ready artifact
      - name: Publish the GitHub release
      - name: Verify the published artifact
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `.github/workflows/release.yml` - 本地环境没有发布证书、Apple 公证凭据及本次正式发布产物，因此无法直接证明 0.83.0 已由 Developer ID 签名、公证并发布。仓库发布契约验证通过，但仍需正式发布工作流成功运行及其最终产物记录才能完全满足该项验收条件。
- `git diff 0427a537dba7059438bd44d22f10c10b3bce8bff..46752484605e3f11599b259020ad4b1ab15f6669 -- packaging/pi-release.json`
- `make test`
- `python3 scripts/check-release-contract.py`
- <code>运行 `build/Pi Launcher.app/Contents/MacOS/pi-launcher --version`，确认最终用户入口输出 `0.83.0`</code>
- `运行真实 Launcher 的无效模型调用，确认参数到达捆绑 Pi 并返回 Pi 的模型错误`
- <code>比较下载 tarball、官方 `SHA256SUMS` 与 `packaging/pi-release.json` 的 arm64 SHA256</code>
- `检查发布工作流中的 Team ID、Developer ID 身份及签名、公证、staple、Gatekeeper 验证和发布顺序`
- <code>`make clean` 并用 `git status --short` 确认工作树未遗留测试生成文件</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
