### PR TITLE
fix: pin release-please tags to bare vX.Y.Z

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,7 +41,9 @@ On GNU/Linux, use `base64 -w0` instead of `base64 -i`. Never commit the `.p12`, 
 4. The called workflow stamps the tag version into the bundle, fetches and re-verifies the pinned upstream Pi, builds, signs inside-out, notarizes, staples, verifies the publication-ready zip, uploads it to the release, then downloads and verifies it again.
 5. If any step fails, do not retry blindly: the failure is the gate working. Fix the cause. The release workflow's manual dispatch remains available for recovery against the existing tag.
 
-The release-please manifest is anchored at the published `v1.1.0` release. Never move it backward or manually reuse an existing version.
+The release-please manifest is anchored at the published `v1.2.0` release. Never move it backward or manually reuse an existing version.
+
+Release-please tags are always bare `v<version>` (`release-please-config.json` sets `include-component-in-tag: false`), matching `release.yml`'s tag parsing, the Homebrew cask download URL, and `scripts/check-release-contract.py`. If `package-name` is ever needed for something else, that flag must stay explicit or a future release-please default change can silently reintroduce a component-prefixed tag (`<package>-v<version>`) that `release.yml` rejects and that ships an empty, asset-less release - exactly what happened with `pi-launcher-v1.2.0`.
 
 ## Artifact contract (consumed by the Homebrew tap)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "pi-launcher"
+      "package-name": "pi-launcher",
+      "include-component-in-tag": false
     }
   }
 }

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -10,8 +10,9 @@ Checks, in order:
   4. release.yml references exactly the canonical secret names
   5. release.yml pins the canonical Team ID and bundle ID
   6. Homebrew tap updates only after the published artifact is verified
-  7. release-please is anchored at v1.1.0, keeps the human path, and gates the
-     autonomous merge mode used by the upstream Pi updater
+  7. release-please is anchored at v1.2.0, tags releases as bare vX.Y.Z with
+     no component prefix, keeps the human path, and gates the autonomous
+     merge mode used by the upstream Pi updater
   8. .github/workflows/ci.yml runs the test suite on pull requests
   9. .github/workflows/upstream-pi-sync.yml gates every upstream Pi bump before
      it can reach main, and quarantines a failure instead of retrying
@@ -245,12 +246,23 @@ release_please_manifest = json.loads(
 )
 release_please_yml = (ROOT / ".github/workflows/release-please.yml").read_text()
 check(
-    "release-please is anchored at published v1.1.0",
-    release_please_manifest == {".": "1.1.0"}
+    "release-please is anchored at published v1.2.0",
+    release_please_manifest == {".": "1.2.0"}
     and release_please_config.get("bootstrap-sha")
     == "431fb3ae841dbb46ac81105b72eb5c62c5b6f997"
     and release_please_config.get("packages", {}).get(".", {}).get("release-type")
     == "simple",
+)
+# Component-in-tag defaults to true upstream, which produced the empty
+# `pi-launcher-v1.2.0` release: release.yml only accepts a bare `vX.Y.Z` tag.
+# This must stay an explicit false, not merely absent, so package-name can
+# never silently reintroduce a component prefix.
+check(
+    "release-please-config.json pins tags to vX.Y.Z with no component prefix",
+    release_please_config.get("packages", {}).get(".", {}).get(
+        "include-component-in-tag"
+    )
+    is False,
 )
 check(
     "release-please calls the signed release workflow after creating a release",


### PR DESCRIPTION
## Summary
- `release-please-config.json` set `package-name: pi-launcher` without `include-component-in-tag: false`, so release-please defaulted to component-prefixed tags. The 1.2.0 release-please PR merge created tag/release `pi-launcher-v1.2.0` instead of `v1.2.0`.
- `release.yml` resolves `${TAG_NAME#v}` and requires a pure `X.Y.Z`, so the signed-release job failed immediately on that tag: `Release tag 'pi-launcher-v1.2.0' must resolve to a version like 1.2.3`. Result: a published GitHub release with zero assets, and the Homebrew tap left pinned at 1.1.0.
- Fix: set `include-component-in-tag: false` so release-please always produces bare `v<version>` tags, matching `release.yml`'s parsing, the cask download URL shape, and `RELEASE.md`'s documented contract.
- Extended `scripts/check-release-contract.py` with an explicit check that `include-component-in-tag` is `false` (not merely absent), so this can't silently regress again. Also refreshed the check's stale "anchored at v1.1.0" assertion to v1.2.0 (the manifest already legitimately moved there) - this was failing on `main` independently of the tag bug.
- Updated `RELEASE.md` to document the tag contract and why the flag must stay explicit.

## Recovery
The broken `pi-launcher-v1.2.0` tag/release (zero assets) will be cleaned up and a real `v1.2.0` published with signed zip + sha256, and the Homebrew tap bumped, as a follow-up recovery action using the existing manual `workflow_dispatch` recovery path documented in `RELEASE.md` - not by weakening any signing/notarization gate.

## Test plan
- [x] `python3 scripts/check-release-contract.py` - all checks pass (was previously failing on `main` due to the stale v1.1.0 anchor)
- [x] `make test` - full local suite (automation, icon, functional, PTY, bundled-Pi smoke) - 86/86 pass
- [x] `bash -n` + `shellcheck -S warning` on all `scripts/*.sh`
- [x] `bash scripts/check-release-ci-exclusions.sh`
