### PR TITLE
fix: align release contract with v1.2.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,7 +41,7 @@ On GNU/Linux, use `base64 -w0` instead of `base64 -i`. Never commit the `.p12`, 
 4. The called workflow stamps the tag version into the bundle, fetches and re-verifies the pinned upstream Pi, builds, signs inside-out, notarizes, staples, verifies the publication-ready zip, uploads it to the release, then downloads and verifies it again.
 5. If any step fails, do not retry blindly: the failure is the gate working. Fix the cause. The release workflow's manual dispatch remains available for recovery against the existing tag.
 
-The release-please manifest is anchored at the published `v1.2.0` release. Never move it backward or manually reuse an existing version.
+The release-please manifest is anchored at the published `v1.2.1` release. Never move it backward or manually reuse an existing version.
 
 Release-please tags are always bare `v<version>` (`release-please-config.json` sets `include-component-in-tag: false`), matching `release.yml`'s tag parsing, the Homebrew cask download URL, and `scripts/check-release-contract.py`. If `package-name` is ever needed for something else, that flag must stay explicit or a future release-please default change can silently reintroduce a component-prefixed tag (`<package>-v<version>`) that `release.yml` rejects and that ships an empty, asset-less release - exactly what happened with `pi-launcher-v1.2.0`.
 

--- a/scripts/check-release-contract.py
+++ b/scripts/check-release-contract.py
@@ -10,7 +10,7 @@ Checks, in order:
   4. release.yml references exactly the canonical secret names
   5. release.yml pins the canonical Team ID and bundle ID
   6. Homebrew tap updates only after the published artifact is verified
-  7. release-please is anchored at v1.2.0, tags releases as bare vX.Y.Z with
+  7. release-please is anchored at v1.2.1, tags releases as bare vX.Y.Z with
      no component prefix, keeps the human path, and gates the autonomous
      merge mode used by the upstream Pi updater
   8. .github/workflows/ci.yml runs the test suite on pull requests
@@ -246,8 +246,8 @@ release_please_manifest = json.loads(
 )
 release_please_yml = (ROOT / ".github/workflows/release-please.yml").read_text()
 check(
-    "release-please is anchored at published v1.2.0",
-    release_please_manifest == {".": "1.2.0"}
+    "release-please is anchored at published v1.2.1",
+    release_please_manifest == {".": "1.2.1"}
     and release_please_config.get("bootstrap-sha")
     == "431fb3ae841dbb46ac81105b72eb5c62c5b6f997"
     and release_please_config.get("packages", {}).get(".", {}).get("release-type")


### PR DESCRIPTION
## Summary
- Reproduced the release-contract CI failure locally.
- Updated the contract assertion and release documentation from v1.2.0 to the actually released v1.2.1.

## Validation
- PASS pi-release.json has all required keys
PASS pi-release.json pins a 64-hex sha256
PASS pi-release.json URLs are https and upstream-pinned
PASS pi-release.json tag/version consistency
PASS upstream SHA256SUMS matches the pinned checksum
PASS release.yml has every required gate in order
PASS release.yml contains 'Verify the publication-ready artifact'
PASS release.yml contains 'Verify the published artifact'
PASS release.yml contains 'runs-on: macos-26'
PASS release.yml launches the signed app, the publication zip, and the published zip
PASS release.yml references exactly the canonical secrets
PASS release.yml pins Team ID, bundle ID, and Developer ID identity
PASS Homebrew update runs only after publication and published-artifact verification
PASS Homebrew update consumes the release version, URL, and checksum outputs
PASS Homebrew tap credentials are ephemeral and absent from the remote URL
PASS Homebrew generator preserves the seeded pi-launcher cask structure
PASS release-please is anchored at published v1.2.1
PASS release-please-config.json pins tags to vX.Y.Z with no component prefix
PASS release-please calls the signed release workflow after creating a release
PASS release-please keeps the human push-to-main path
PASS release-please auto-merge is an opt-in, guarded, two-pass mode
PASS release.yml supports release-please while retaining tag and manual triggers
PASS ci.yml runs the full test suite on pull_request
PASS ci.yml runs the release automation script tests
PASS ci.yml does not reference signing secrets
PASS upstream-pi-sync runs on a schedule and never cancels itself mid-release
PASS upstream-pi-sync discovers on Ubuntu and gates on macOS
PASS upstream-pi-sync never reads a signing or notarization secret
PASS upstream-pi-sync gates the candidate pin before it can reach main
PASS upstream-pi-sync pushes only onto the exact commit it tested
PASS upstream-pi-sync releases only through release-please autonomous mode
PASS upstream-pi-sync quarantines a failure instead of retrying it
PASS cask url matches the release asset naming
PASS cask installs the app and a binary shim
PASS cask sha256 is a placeholder for the tap task
PASS no private key material tracked

contract: all checks passed passes all checks.
- release-please CI exclusions ok (.release-please-manifest.json, CHANGELOG.md, version.txt) across .github/workflows/ci.yml passes.

The contract check remains unchanged in scope and is not weakened or removed.